### PR TITLE
[TASK] Provide JSON schema for config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ rootPath: ../
   they are configured as relative paths. If the root path is configured
   as relative path, it is calculated based on the config file path.
 
+> [!TIP]
+> Have a look at the shipped [JSON schema](res/version-bumper.schema.json).
+
 ### Configuration in `composer.json`
 
 The config file path can be passed as `-c`/`--config` command

--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -1,0 +1,50 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"type": "object",
+	"title": "Version Bumper config file schema",
+	"properties": {
+		"filesToModify": {
+			"type": "array",
+			"title": "List of files that contain versions which are to be bumped",
+			"items": {
+				"$ref": "#/definitions/fileToModify"
+			}
+		},
+		"rootPath": {
+			"type": "string",
+			"title": "Relative or absolute path to project root",
+			"description": "This path will be used to calculate paths to configured files if they are configured as relative paths. If the root path is configured as relative path, it is calculated based on the config file path."
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"filesToModify"
+	],
+	"definitions": {
+		"fileToModify": {
+			"type": "object",
+			"title": "A file that contains versions which are to be bumped",
+			"properties": {
+				"path": {
+					"type": "string",
+					"title": "Relative or absolute path to the file",
+					"description": "Relative paths are calculated from the configured (or calculated) project root."
+				},
+				"patterns": {
+					"type": "array",
+					"title": "List of version patterns to be searched and replaced in the configured file",
+					"description": "Each pattern must contain a `{%version%}` placeholder that is replaced by the new version. Patterns are internally converted to regular expressions, so feel free to use regex syntax such as `\\s+`.",
+					"items": {
+						"type": "string",
+						"pattern": "\\{%version%\\}"
+					}
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"path",
+				"patterns"
+			]
+		}
+	}
+}


### PR DESCRIPTION
This PR provides a JSON schema for `version-bumper` config files. This allows to easily write config files while validating against the schema, e.g. directly in an IDE.