### PR TITLE
[FEATURE] Add option to report unmatched file patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,19 +128,22 @@ filesToModify:
     patterns:
       # Each pattern must contain a {%version%} placeholder
       - '"version": "{%version%}"'
+    reportUnmatched: true
 # Relative (to config file) or absolute path to project root
 rootPath: ../
 ```
 
 * `filesToModify` (required): List of files that contain versions which
-  are to be bumped. Each item must contain the following properties:
-  - `path`: Relative or absolute path to the file. Relative paths
-    are calculated from the configured (or calculated) project root.
-  - `patterns`: List of version patterns to be searched and replaced
-    in the configured file. Each pattern must contain a
+  are to be bumped. Each item accepts the following properties:
+  - `path` (required): Relative or absolute path to the file. Relative
+    paths are calculated from the configured (or calculated) project root.
+  - `patterns` (required): List of version patterns to be searched and
+  - replaced in the configured file. Each pattern must contain a
     `{%version%}` placeholder that is replaced by the new version.
     Patterns are internally converted to regular expressions, so
     feel free to use regex syntax such as `\s+`.
+  - `reportUnmatched` (optional): Show warning if a configured pattern
+    does not match file contents.
 * `rootPath` (optional): Relative or absolute path to project root.
   This path will be used to calculate paths to configured files if
   they are configured as relative paths. If the root path is configured

--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -38,6 +38,10 @@
 						"type": "string",
 						"pattern": "\\{%version%\\}"
 					}
+				},
+				"reportUnmatched": {
+					"type": "boolean",
+					"title": "Show warning if a configured pattern does not match file contents"
 				}
 			},
 			"additionalProperties": false,

--- a/src/Command/BumpVersionCommand.php
+++ b/src/Command/BumpVersionCommand.php
@@ -170,10 +170,11 @@ final class BumpVersionCommand extends Command\BaseCommand
                 $message = match ($operation->state()) {
                     Enum\OperationState::Modified => sprintf(
                         '✅ Bumped version from "%s" to "%s"',
-                        $operation->source()->full(),
-                        $operation->target()->full(),
+                        $operation->source()?->full(),
+                        $operation->target()?->full(),
                     ),
                     Enum\OperationState::Skipped => '⏩ Skipped file due to unmodified contents',
+                    Enum\OperationState::Unmatched => '❓ Unmatched file pattern: '.$operation->pattern()->original(),
                 };
 
                 if ($numberOfOperations > 1) {

--- a/src/Config/FilePattern.php
+++ b/src/Config/FilePattern.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Config;
+
+use EliasHaeussler\VersionBumper\Exception;
+
+use function addcslashes;
+use function str_replace;
+
+/**
+ * FilePattern.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class FilePattern
+{
+    private const VERSION_PLACEHOLDER = '{%version%}';
+    private const VERSION_REGEX = '(?P<version>\\d+\\.\\d+\\.\\d+)';
+
+    private readonly string $original;
+    private readonly string $regularExpression;
+
+    /**
+     * @throws Exception\FilePatternIsInvalid
+     */
+    public function __construct(string $pattern)
+    {
+        if (!str_contains($pattern, self::VERSION_PLACEHOLDER)) {
+            throw new Exception\FilePatternIsInvalid($pattern);
+        }
+
+        $this->original = $pattern;
+        $this->regularExpression = $this->patternToRegex($pattern);
+    }
+
+    public function original(): string
+    {
+        return $this->original;
+    }
+
+    public function regularExpression(): string
+    {
+        return $this->regularExpression;
+    }
+
+    private function patternToRegex(string $pattern): string
+    {
+        return '/'.str_replace(self::VERSION_PLACEHOLDER, self::VERSION_REGEX, addcslashes($pattern, '/')).'/';
+    }
+}

--- a/src/Exception/SourceVersionIsMissing.php
+++ b/src/Exception/SourceVersionIsMissing.php
@@ -21,17 +21,18 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\VersionBumper\Enum;
+namespace EliasHaeussler\VersionBumper\Exception;
 
 /**
- * OperationState.
+ * SourceVersionIsMissing.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-enum OperationState
+final class SourceVersionIsMissing extends Exception
 {
-    case Modified;
-    case Skipped;
-    case Unmatched;
+    public function __construct()
+    {
+        parent::__construct('No source version given.', 1727170609);
+    }
 }

--- a/src/Exception/TargetVersionIsMissing.php
+++ b/src/Exception/TargetVersionIsMissing.php
@@ -21,17 +21,18 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\VersionBumper\Enum;
+namespace EliasHaeussler\VersionBumper\Exception;
 
 /**
- * OperationState.
+ * TargetVersionIsMissing.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-enum OperationState
+final class TargetVersionIsMissing extends Exception
 {
-    case Modified;
-    case Skipped;
-    case Unmatched;
+    public function __construct()
+    {
+        parent::__construct('No target version given.', 1727170622);
+    }
 }

--- a/src/Exception/VersionBumpResultIsMissing.php
+++ b/src/Exception/VersionBumpResultIsMissing.php
@@ -21,17 +21,18 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\VersionBumper\Enum;
+namespace EliasHaeussler\VersionBumper\Exception;
 
 /**
- * OperationState.
+ * VersionBumpResultIsMissing.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-enum OperationState
+final class VersionBumpResultIsMissing extends Exception
 {
-    case Modified;
-    case Skipped;
-    case Unmatched;
+    public function __construct()
+    {
+        parent::__construct('No version bump result given.', 1727170645);
+    }
 }

--- a/src/Result/VersionBumpResult.php
+++ b/src/Result/VersionBumpResult.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\VersionBumper\Result;
 
 use EliasHaeussler\VersionBumper\Config;
+use EliasHaeussler\VersionBumper\Enum;
 
 use function array_values;
 use function sprintf;
@@ -57,6 +58,11 @@ final class VersionBumpResult
         return $this->operations;
     }
 
+    public function hasOperations(): bool
+    {
+        return [] !== $this->operations;
+    }
+
     /**
      * @return list<non-empty-list<WriteOperation>>
      */
@@ -66,10 +72,11 @@ final class VersionBumpResult
 
         foreach ($this->operations as $operation) {
             $identifier = sprintf(
-                '%s_%s_%s',
-                $operation->source()->full(),
-                $operation->target()->full(),
+                '%s_%s_%s_%s',
+                $operation->source()?->full(),
+                $operation->target()?->full(),
                 $operation->state()->name,
+                Enum\OperationState::Unmatched === $operation->state() ? $operation->pattern()->original() : '',
             );
 
             if (!isset($operations[$identifier])) {
@@ -80,5 +87,16 @@ final class VersionBumpResult
         }
 
         return array_values($operations);
+    }
+
+    public function hasUnmatchedReports(): bool
+    {
+        foreach ($this->operations as $operation) {
+            if (Enum\OperationState::Unmatched === $operation->state()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/src/Command/BumpVersionCommandTest.php
+++ b/tests/src/Command/BumpVersionCommandTest.php
@@ -173,6 +173,7 @@ final class BumpVersionCommandTest extends Framework\TestCase
 
         self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
         self::assertStringContainsString('Bumped version from "1.0.0" to "2.0.0" (2x)', $output);
+        self::assertStringContainsString('Unmatched file pattern: foo: {%version%}', $output);
         self::assertStringContainsString('Skipped file due to unmodified contents', $output);
         self::assertStringContainsString('No write operations were performed (dry-run mode).', $output);
     }

--- a/tests/src/Config/FilePatternTest.php
+++ b/tests/src/Config/FilePatternTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Config;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
+
+/**
+ * FilePatternTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Config\FilePattern::class)]
+final class FilePatternTest extends Framework\TestCase
+{
+    private Src\Config\FilePattern $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Config\FilePattern('foo/foo: {%version%}');
+    }
+
+    #[Framework\Attributes\Test]
+    public function constructorThrowsExceptionIfVersionPlaceholderIsMissing(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\FilePatternIsInvalid('foo'),
+        );
+
+        new Src\Config\FilePattern('foo');
+    }
+
+    #[Framework\Attributes\Test]
+    public function constructorConvertsPatternToRegularExpression(): void
+    {
+        self::assertSame('foo/foo: {%version%}', $this->subject->original());
+        self::assertSame('/foo\/foo: (?P<version>\d+\.\d+\.\d+)/', $this->subject->regularExpression());
+    }
+}

--- a/tests/src/Config/FileToModifyTest.php
+++ b/tests/src/Config/FileToModifyTest.php
@@ -70,26 +70,24 @@ final class FileToModifyTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function addThrowsExceptionIfVersionPlaceholderIsMissing(): void
+    public function addAcceptsFilePatternString(): void
     {
-        $this->expectExceptionObject(
-            new Src\Exception\FilePatternIsInvalid('foo'),
-        );
+        $this->subject->add('foo/foo: {%version%}');
 
-        $this->subject->add('foo');
+        $expected = new Src\Config\FilePattern('foo/foo: {%version%}');
+
+        self::assertCount(1, $this->subject->patterns());
+        self::assertEquals($expected, $this->subject->patterns()[0]);
     }
 
     #[Framework\Attributes\Test]
-    public function addConvertsPatternsToRegularExpressions(): void
+    public function addAcceptsFilePatternObject(): void
     {
-        $this->subject->add('foo/foo: {%version%}');
-        $this->subject->add('baz/baz: {%version%}');
+        $pattern = new Src\Config\FilePattern('foo/foo: {%version%}');
 
-        $expected = [
-            '/foo\/foo: (?P<version>\d+\.\d+\.\d+)/',
-            '/baz\/baz: (?P<version>\d+\.\d+\.\d+)/',
-        ];
+        $this->subject->add($pattern);
 
-        self::assertSame($expected, $this->subject->patterns());
+        self::assertCount(1, $this->subject->patterns());
+        self::assertSame($pattern, $this->subject->patterns()[0]);
     }
 }

--- a/tests/src/Exception/SourceVersionIsMissingTest.php
+++ b/tests/src/Exception/SourceVersionIsMissingTest.php
@@ -21,17 +21,26 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\VersionBumper\Enum;
+namespace EliasHaeussler\VersionBumper\Tests\Exception;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
 
 /**
- * OperationState.
+ * SourceVersionIsMissingTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-enum OperationState
+#[Framework\Attributes\CoversClass(Src\Exception\SourceVersionIsMissing::class)]
+final class SourceVersionIsMissingTest extends Framework\TestCase
 {
-    case Modified;
-    case Skipped;
-    case Unmatched;
+    #[Framework\Attributes\Test]
+    public function constructorCreatesExceptionForMissingSourceVersion(): void
+    {
+        $actual = new Src\Exception\SourceVersionIsMissing();
+
+        self::assertSame('No source version given.', $actual->getMessage());
+        self::assertSame(1727170609, $actual->getCode());
+    }
 }

--- a/tests/src/Exception/TargetVersionIsMissingTest.php
+++ b/tests/src/Exception/TargetVersionIsMissingTest.php
@@ -21,17 +21,26 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\VersionBumper\Enum;
+namespace EliasHaeussler\VersionBumper\Tests\Exception;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
 
 /**
- * OperationState.
+ * TargetVersionIsMissingTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-enum OperationState
+#[Framework\Attributes\CoversClass(Src\Exception\TargetVersionIsMissing::class)]
+final class TargetVersionIsMissingTest extends Framework\TestCase
 {
-    case Modified;
-    case Skipped;
-    case Unmatched;
+    #[Framework\Attributes\Test]
+    public function constructorCreatesExceptionForMissingTargetVersion(): void
+    {
+        $actual = new Src\Exception\TargetVersionIsMissing();
+
+        self::assertSame('No target version given.', $actual->getMessage());
+        self::assertSame(1727170622, $actual->getCode());
+    }
 }

--- a/tests/src/Exception/VersionBumpResultIsMissingTest.php
+++ b/tests/src/Exception/VersionBumpResultIsMissingTest.php
@@ -21,17 +21,26 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\VersionBumper\Enum;
+namespace EliasHaeussler\VersionBumper\Tests\Exception;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
 
 /**
- * OperationState.
+ * VersionBumpResultIsMissingTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-enum OperationState
+#[Framework\Attributes\CoversClass(Src\Exception\VersionBumpResultIsMissing::class)]
+final class VersionBumpResultIsMissingTest extends Framework\TestCase
 {
-    case Modified;
-    case Skipped;
-    case Unmatched;
+    #[Framework\Attributes\Test]
+    public function constructorCreatesExceptionForMissingVersionBumpResult(): void
+    {
+        $actual = new Src\Exception\VersionBumpResultIsMissing();
+
+        self::assertSame('No version bump result given.', $actual->getMessage());
+        self::assertSame(1727170645, $actual->getCode());
+    }
 }

--- a/tests/src/Fixtures/ConfigFiles/valid-config-with-root-path.json
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-with-root-path.json
@@ -3,8 +3,10 @@
 		{
 			"path": "foo",
 			"patterns": [
-				"baz: {%version%}"
-			]
+				"baz: {%version%}",
+				"foo: {%version%}"
+			],
+			"reportUnmatched": true
 		},
 		{
 			"path": "baz",

--- a/tests/src/Result/VersionBumpResultTest.php
+++ b/tests/src/Result/VersionBumpResultTest.php
@@ -52,6 +52,7 @@ final class VersionBumpResultTest extends Framework\TestCase
                     new Src\Version\Version(2, 0, 0),
                     '"name": "foo/baz",
         "version": "2.0.0"',
+                    new Src\Config\FilePattern('"version": "{%version%}"'),
                     Src\Enum\OperationState::Modified,
                 ),
                 new Src\Result\WriteOperation(
@@ -59,6 +60,7 @@ final class VersionBumpResultTest extends Framework\TestCase
                     new Src\Version\Version(2, 0, 0),
                     '"name": "foo/baz",
     "version": "2.0.0"',
+                    new Src\Config\FilePattern('"version": "{%version%}"'),
                     Src\Enum\OperationState::Modified,
                 ),
                 new Src\Result\WriteOperation(
@@ -66,7 +68,14 @@ final class VersionBumpResultTest extends Framework\TestCase
                     new Src\Version\Version(2, 0, 0),
                     '"name": "foo/baz",
     "version": "2.0.0"',
+                    new Src\Config\FilePattern('"version": "{%version%}"'),
                     Src\Enum\OperationState::Modified,
+                ),
+                Src\Result\WriteOperation::unmatched(
+                    new Src\Config\FilePattern('"foo/version": "{%version%}"'),
+                ),
+                Src\Result\WriteOperation::unmatched(
+                    new Src\Config\FilePattern('"baz/version": "{%version%}"'),
                 ),
             ],
         );
@@ -83,6 +92,7 @@ final class VersionBumpResultTest extends Framework\TestCase
                     new Src\Version\Version(2, 0, 0),
                     '"name": "foo/baz",
         "version": "2.0.0"',
+                    new Src\Config\FilePattern('"version": "{%version%}"'),
                     Src\Enum\OperationState::Modified,
                 ),
                 new Src\Result\WriteOperation(
@@ -90,6 +100,7 @@ final class VersionBumpResultTest extends Framework\TestCase
                     new Src\Version\Version(2, 0, 0),
                     '"name": "foo/baz",
     "version": "2.0.0"',
+                    new Src\Config\FilePattern('"version": "{%version%}"'),
                     Src\Enum\OperationState::Modified,
                 ),
             ],
@@ -100,11 +111,67 @@ final class VersionBumpResultTest extends Framework\TestCase
                     new Src\Version\Version(2, 0, 0),
                     '"name": "foo/baz",
     "version": "2.0.0"',
+                    new Src\Config\FilePattern('"version": "{%version%}"'),
                     Src\Enum\OperationState::Modified,
+                ),
+            ],
+            // Unmatched: "foo/version": "{%version%}"
+            [
+                Src\Result\WriteOperation::unmatched(
+                    new Src\Config\FilePattern('"foo/version": "{%version%}"'),
+                ),
+            ],
+            // Unmatched: "baz/version": "{%version%}"
+            [
+                Src\Result\WriteOperation::unmatched(
+                    new Src\Config\FilePattern('"baz/version": "{%version%}"'),
                 ),
             ],
         ];
 
         self::assertEquals($expected, $this->subject->groupedOperations());
+    }
+
+    #[Framework\Attributes\Test]
+    public function hasUnmatchedReportsReturnsTrueIfAnyWriteOperationHasUnmatchedOperationState(): void
+    {
+        self::assertTrue($this->subject->hasUnmatchedReports());
+
+        $subject = new Src\Result\VersionBumpResult(
+            new Src\Config\FileToModify(
+                'package-lock.json',
+                [
+                    '"name": "foo/baz",\s+"version": "{%version%}"',
+                ],
+            ),
+            [
+                new Src\Result\WriteOperation(
+                    new Src\Version\Version(1, 2, 3),
+                    new Src\Version\Version(2, 0, 0),
+                    '"name": "foo/baz",
+        "version": "2.0.0"',
+                    new Src\Config\FilePattern('"version": "{%version%}"'),
+                    Src\Enum\OperationState::Modified,
+                ),
+                new Src\Result\WriteOperation(
+                    new Src\Version\Version(1, 2, 3),
+                    new Src\Version\Version(2, 0, 0),
+                    '"name": "foo/baz",
+    "version": "2.0.0"',
+                    new Src\Config\FilePattern('"version": "{%version%}"'),
+                    Src\Enum\OperationState::Modified,
+                ),
+                new Src\Result\WriteOperation(
+                    new Src\Version\Version(1, 2, 0),
+                    new Src\Version\Version(2, 0, 0),
+                    '"name": "foo/baz",
+    "version": "2.0.0"',
+                    new Src\Config\FilePattern('"version": "{%version%}"'),
+                    Src\Enum\OperationState::Modified,
+                ),
+            ],
+        );
+
+        self::assertFalse($subject->hasUnmatchedReports());
     }
 }

--- a/tests/src/Result/WriteOperationTest.php
+++ b/tests/src/Result/WriteOperationTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Result;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
+
+/**
+ * WriteOperationTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Result\WriteOperation::class)]
+final class WriteOperationTest extends Framework\TestCase
+{
+    private Src\Result\WriteOperation $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Result\WriteOperation(
+            new Src\Version\Version(1, 0, 0),
+            new Src\Version\Version(2, 0, 0),
+            '',
+            new Src\Config\FilePattern('foo: {%version%}'),
+            Src\Enum\OperationState::Skipped,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function constructorThrowsExceptionOnMissingSourceVersion(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\SourceVersionIsMissing(),
+        );
+
+        new Src\Result\WriteOperation(
+            null,
+            new Src\Version\Version(2, 0, 0),
+            '',
+            new Src\Config\FilePattern('foo: {%version%}'),
+            Src\Enum\OperationState::Skipped,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function constructorThrowsExceptionOnMissingTargetVersion(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\TargetVersionIsMissing(),
+        );
+
+        new Src\Result\WriteOperation(
+            new Src\Version\Version(1, 0, 0),
+            null,
+            '',
+            new Src\Config\FilePattern('foo: {%version%}'),
+            Src\Enum\OperationState::Skipped,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function constructorThrowsExceptionOnMissingResult(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\VersionBumpResultIsMissing(),
+        );
+
+        new Src\Result\WriteOperation(
+            new Src\Version\Version(1, 0, 0),
+            new Src\Version\Version(2, 0, 0),
+            null,
+            new Src\Config\FilePattern('foo: {%version%}'),
+            Src\Enum\OperationState::Skipped,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function matchedReturnsTrueIfOperationStateIsNotUnmatched(): void
+    {
+        self::assertTrue($this->subject->matched());
+
+        $subject = Src\Result\WriteOperation::unmatched(
+            new Src\Config\FilePattern('foo: {%version%}'),
+        );
+
+        self::assertFalse($subject->matched());
+    }
+}

--- a/tests/src/Version/VersionBumperTest.php
+++ b/tests/src/Version/VersionBumperTest.php
@@ -93,6 +93,7 @@ baz: 1.0.0
 baz: 1.0.0
 
 FOO,
+                new Src\Config\FilePattern('baz: {%version%}'),
                 Src\Enum\OperationState::Skipped,
             ),
             new Src\Result\WriteOperation(
@@ -103,6 +104,56 @@ baz: 1.0.0
 baz: 1.0.0
 
 FOO,
+                new Src\Config\FilePattern('baz: {%version%}'),
+                Src\Enum\OperationState::Skipped,
+            ),
+        ];
+
+        $actual = $this->subject->bump($files, $rootPath, '1.0.0');
+
+        self::assertCount(1, $actual);
+        self::assertSame($fooFile, $actual[0]->file());
+        self::assertEquals($expected, $actual[0]->operations());
+    }
+
+    #[Framework\Attributes\Test]
+    public function bumpReportsUnmatchedPattern(): void
+    {
+        $fooFile = new Src\Config\FileToModify(
+            'foo',
+            [
+                'foo: {%version%}',
+                'baz: {%version%}',
+            ],
+            true,
+        );
+        $files = [$fooFile];
+        $rootPath = dirname(__DIR__).'/Fixtures/RootPath';
+
+        $expected = [
+            Src\Result\WriteOperation::unmatched(
+                new Src\Config\FilePattern('foo: {%version%}'),
+            ),
+            new Src\Result\WriteOperation(
+                new Src\Version\Version(1, 0, 0),
+                new Src\Version\Version(1, 0, 0),
+                <<<FOO
+baz: 1.0.0
+baz: 1.0.0
+
+FOO,
+                new Src\Config\FilePattern('baz: {%version%}'),
+                Src\Enum\OperationState::Skipped,
+            ),
+            new Src\Result\WriteOperation(
+                new Src\Version\Version(1, 0, 0),
+                new Src\Version\Version(1, 0, 0),
+                <<<FOO
+baz: 1.0.0
+baz: 1.0.0
+
+FOO,
+                new Src\Config\FilePattern('baz: {%version%}'),
                 Src\Enum\OperationState::Skipped,
             ),
         ];
@@ -132,6 +183,7 @@ baz: 1.1.0
 baz: 1.0.0
 
 FOO,
+                new Src\Config\FilePattern('baz: {%version%}'),
                 Src\Enum\OperationState::Modified,
             ),
             new Src\Result\WriteOperation(
@@ -142,6 +194,7 @@ baz: 1.1.0
 baz: 1.1.0
 
 FOO,
+                new Src\Config\FilePattern('baz: {%version%}'),
                 Src\Enum\OperationState::Modified,
             ),
         ];
@@ -172,6 +225,7 @@ foo: 2.1.0
 baz: 3.0.0
 
 BAZ,
+                new Src\Config\FilePattern('foo: {%version%}'),
                 Src\Enum\OperationState::Modified,
             ),
             new Src\Result\WriteOperation(
@@ -182,6 +236,7 @@ foo: 2.1.0
 baz: 3.1.0
 
 BAZ,
+                new Src\Config\FilePattern('baz: {%version%}'),
                 Src\Enum\OperationState::Modified,
             ),
         ];


### PR DESCRIPTION
This PR adds a new `reportUnmatched` option to `filesToModify` config option. This leads to a `WriteOperation::Unmatched` operation in the resulting `VersionBumpResult` for all unmatched file patterns.