### PR TITLE
[FEATURE] Add `--strict` option to `bump-version` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ composer require --dev eliashaeussler/version-bumper
 ### Console command `bump-version`
 
 ```bash
-$ composer bump-version <range> [-c|--config CONFIG] [--dry-run]
+$ composer bump-version <range> [-c|--config CONFIG] [--dry-run] [--strict]
 ```
 
 Pass the following options to the console command:
@@ -44,9 +44,10 @@ Pass the following options to the console command:
 * `-c`/`--config`: Path to [config file](#-configuration),
   defaults to auto-detection in current working directory,
   can be configured in `composer.json` as well (see
-  config section below)
+  config section below).
 * `--dry-run`: Do not perform any write operations, just
-  calculate and display version bumps
+  calculate and display version bumps.
+* `--strict`: Fail if any unmatched file pattern is reported.
 
 ### PHP API
 
@@ -138,12 +139,13 @@ rootPath: ../
   - `path` (required): Relative or absolute path to the file. Relative
     paths are calculated from the configured (or calculated) project root.
   - `patterns` (required): List of version patterns to be searched and
-  - replaced in the configured file. Each pattern must contain a
+    replaced in the configured file. Each pattern must contain a
     `{%version%}` placeholder that is replaced by the new version.
     Patterns are internally converted to regular expressions, so
     feel free to use regex syntax such as `\s+`.
   - `reportUnmatched` (optional): Show warning if a configured pattern
-    does not match file contents.
+    does not match file contents. Useful in combination with the
+    `--strict` command option.
 * `rootPath` (optional): Relative or absolute path to project root.
   This path will be used to calculate paths to configured files if
   they are configured as relative paths. If the root path is configured

--- a/src/Command/BumpVersionCommand.php
+++ b/src/Command/BumpVersionCommand.php
@@ -95,6 +95,12 @@ final class BumpVersionCommand extends Command\BaseCommand
             Console\Input\InputOption::VALUE_NONE,
             'Do not perform any write operations, just calculate version bumps',
         );
+        $this->addOption(
+            'strict',
+            null,
+            Console\Input\InputOption::VALUE_NONE,
+            'Fail if any unmatched file pattern is reported',
+        );
     }
 
     protected function initialize(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): void
@@ -108,6 +114,7 @@ final class BumpVersionCommand extends Command\BaseCommand
         $rangeOrVersion = $input->getArgument('range');
         $configFile = $input->getOption('config') ?? $this->configReader->detectFile($rootPath);
         $dryRun = $input->getOption('dry-run');
+        $strict = $input->getOption('strict');
 
         if (null === $configFile) {
             $this->io->error('Please provide a config file path using the --config option.');
@@ -145,6 +152,14 @@ final class BumpVersionCommand extends Command\BaseCommand
 
         if ($dryRun) {
             $this->io->note('No write operations were performed (dry-run mode).');
+        }
+
+        if ($strict) {
+            foreach ($results as $result) {
+                if ($result->hasUnmatchedReports()) {
+                    return self::FAILURE;
+                }
+            }
         }
 
         return self::SUCCESS;

--- a/tests/src/Command/BumpVersionCommandTest.php
+++ b/tests/src/Command/BumpVersionCommandTest.php
@@ -178,6 +178,25 @@ final class BumpVersionCommandTest extends Framework\TestCase
         self::assertStringContainsString('No write operations were performed (dry-run mode).', $output);
     }
 
+    #[Framework\Attributes\Test]
+    public function executeFailsIfUnmatchedPatternIsReportedInStrictMode(): void
+    {
+        $configFile = dirname(__DIR__).'/Fixtures/ConfigFiles/valid-config-with-root-path.json';
+
+        $this->commandTester->execute([
+            'range' => '1.0.0',
+            '--config' => $configFile,
+            '--dry-run' => true,
+            '--strict' => true,
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertSame(Console\Command\Command::FAILURE, $this->commandTester->getStatusCode());
+        self::assertStringContainsString('Unmatched file pattern: foo: {%version%}', $output);
+        self::assertStringContainsString('Bumped version from "2.0.0" to "1.0.0"', $output);
+    }
+
     private function createCommandTester(?Composer $composer = null): Console\Tester\CommandTester
     {
         $application = new Application();


### PR DESCRIPTION
This PR adds a new `--strict` command option to `bump-version` command. It makes the command fail as soon as an unmatched file pattern is reported.