### PR TITLE
[FEATURE] Introduce version range detector component

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,13 @@ composer require --dev eliashaeussler/version-bumper
 
 ### Console command `bump-version`
 
+> [!TIP]
+> The `<range>` command option can be omitted if
+> [version range auto-detection](#version-range-auto-detection)
+> is properly configured.
+
 ```bash
-$ composer bump-version <range> [-c|--config CONFIG] [-r|--release] [--dry-run] [--strict]
+$ composer bump-version [<range>] [-c|--config CONFIG] [-r|--release] [--dry-run] [--strict]
 ```
 
 Pass the following options to the console command:
@@ -51,10 +56,131 @@ Pass the following options to the console command:
   calculate and display version bumps.
 * `--strict`: Fail if any unmatched file pattern is reported.
 
+#### Version range auto-detection
+
+Normally, an explicit version range or version is passed to
+the `bump-version` command. However, it may become handy if
+a version range is auto-detected, based on the Git history.
+This sort of auto-detection is automatically triggered if the
+`<range>` command option is omitted.
+
+> [!IMPORTANT]
+> Auto-detection is only possible if [`versionRangeIndicators`](#version-range-indicators)
+> are configured in the config file.
+
+To use the auto-detection feature, make sure to add version
+range indicators to your config file:
+
+```yaml
+versionRangeIndicators:
+  # 1️⃣ Bump major version on breaking changes, determined by commit message
+  - range: major
+    patterns:
+      - type: commitMessage
+        pattern: '/^\[!!!]/'
+
+  # 2️⃣ Bump major version if controllers are deleted and API schema changes
+  - range: major
+    # All configured patterns must match to use this indicator
+    strategy: matchAll
+    patterns:
+      - type: fileDeleted
+        pattern: '/^src\/Controller\/.+Controller\.php$/'
+      - type: fileModified
+        pattern: '/^res\/api\.schema\.json$/'
+
+  # 3️⃣ Bump minor version when new features are added
+  - range: minor
+    patterns:
+      - type: commitMessage
+        pattern: '/^\[FEATURE]/'
+
+  # 4️⃣ Bump patch version if maintenance or documentation tasks were performed
+  - range: patch
+    patterns:
+      - type: commitMessage
+        pattern: '/^\[TASK]/'
+      - type: commitMessage
+        pattern: '/^\[BUGFIX]/'
+      - type: commitMessage
+        pattern: '/^\[DOCS]/'
+
+  # 5️⃣ Bump patch version if no sources have changed
+  - range: patch
+    # No configured patterns must match to use this indicator
+    strategy: matchNone
+    patterns:
+      - type: fileAdded
+        pattern: '/^src\//'
+      - type: fileDeleted
+        pattern: '/^src\//'
+      - type: fileModified
+        pattern: '/^src\//'
+```
+
+> [!NOTE]
+> The matching version range with the highest priority will be
+> used as final version range (`major` receives the highest priority).
+
+If no version range indicator matches, the `bump-version`
+command will fail.
+
+##### Strategies
+
+The `strategy` config option (see second indicator in the above example)
+defines how matching (or non-matching) patterns are treated to
+mark the whole indicator as "matching".
+
+By default, an indicator matches if any of the configured
+patterns matches (`matchAny`). If all patterns must match,
+`matchAll` can be used.
+
+In some cases, it may be useful to define a version range if
+no pattern matches. This can be achieved by the `matchNone` strategy.
+
+##### Examples
+
+Using the above example, the following version range would result
+if given preconditions are met:
+
+| Commit message                                     | File operations                                                                                  | Matching range                |
+|----------------------------------------------------|--------------------------------------------------------------------------------------------------|-------------------------------|
+| `[!!!][TASK] Drop support for PHP < 8.3`           | *any*                                                                                            | 1️⃣&nbsp;`major`              |
+| *any*                                              | Deleted:&nbsp;`src/Controller/DashboardController.php`<br>Modified:&nbsp;`res/api.schema.json`   | 2️⃣&nbsp;`major`              |
+| `[FEATURE] Add support for PHP 8.4`                | *any*                                                                                            | 3️⃣&nbsp;`minor`              |
+| `[TASK] Use PHP 8.4 in CI`                         | *any*                                                                                            | 4️⃣&nbsp;`patch`              |
+| `[BUGFIX] Avoid implicit nullable types`           | *any*                                                                                            | 4️⃣&nbsp;`patch`              |
+| `[DOCS] Mention PHP 8.4 support in documentation`  | *any*                                                                                            | 4️⃣&nbsp;`patch`              |
+| *any*                                              | Modified:&nbsp;`composer.json`<br>Added:`composer.lock`<br>Deleted:&nbsp;`composer.patches.json` | 5️⃣&nbsp;`patch`              |
+| `[TASK] Remove deprecated dashboard functionality` | Deleted:&nbsp;`src/Controller/DashboardController.php`<br>Modified:&nbsp;`res/api.schema.json`   | 2️⃣&nbsp;`major`<sup>1)</sup> |
+| `[TASK] Remove deprecated dashboard functionality` | Deleted:&nbsp;`src/Controller/DashboardController.php`                                           | 4️⃣&nbsp;`patch`<sup>2)</sup> |
+| `[SECURITY] Avoid XSS in dashboard`                | Modified:&nbsp;`src/Controller/DashboardController.php`                                          | –<sup>3)</sup>                |
+
+*Notes:*
+
+<sup>1)</sup> Even if both indicators 2️⃣ and 4️⃣ match, indicator
+2️⃣ takes precedence because of the higher version range.
+
+<sup>2)</sup> Indicator 2️⃣ does not match, because only one
+pattern matches, and the indicator's strategy is configured
+to match all patterns (`matchAll`).
+
+<sup>3)</sup> No indicator contains patterns for either the
+commit message or modified file, hence no version range is
+detected.
+
+
 ### PHP API
 
+> [!TIP]
+> You can use the method argument `$dryRun` in both
+> `VersionBumper` and `VersionReleaser` classes to skip any
+> write operations (dry-run mode).
+
+#### Bump versions
+
 The main entrypoint of the plugin is the
-[`Version\VersionBumper`](src/Version/VersionBumper.php) class.
+[`Version\VersionBumper`](src/Version/VersionBumper.php) class:
 
 ```php
 use EliasHaeussler\VersionBumper;
@@ -108,6 +234,8 @@ foreach ($results as $result) {
 }
 ```
 
+#### Create release
+
 A release can be created by the
 [`Version\VersionReleaser`](src/Version/VersionReleaser.php) class:
 
@@ -131,10 +259,38 @@ echo sprintf(
 echo PHP_EOL;
 ```
 
-> [!TIP]
-> You can use the method argument `$dryRun` in both
-> `VersionBumper` and `VersionReleaser` classes to skip any
-> write operations (dry-run mode).
+#### Auto-detect version range
+
+When bumping files, a respective version range or explicit version
+must be provided (see above). The library provides a
+[`Version\VersionRangeDetector`](src/Version/VersionRangeDetector.php)
+class to automate this step and auto-detect a version range, based
+on a set of [`Config\VersionRangeIndicator`](src/Config/VersionRangeIndicator.php)
+objects:
+
+```php
+use EliasHaeussler\VersionBumper;
+
+$indicators = [
+    new VersionBumper\Config\VersionRangeIndicator(
+        // Bump major version if any commit contains breaking changes
+        // (commit message starts with "[!!!]")
+        VersionBumper\Enum\VersionRange::Major,
+        [
+            new VersionBumper\Config\VersionRangePattern(
+                VersionBumper\Enum\VersionRangeIndicatorType::CommitMessage,
+                '/^\[!!!]/',
+            ),
+        ],
+    ),
+];
+
+$versionRangeDetector = new VersionBumper\Version\VersionRangeDetector();
+$versionRange = $versionRangeDetector->detect($rootPath, $indicators);
+
+echo sprintf('Auto-detected version range is "%s".', $versionRange->value);
+echo PHP_EOL;
+```
 
 ## 📝 Configuration
 
@@ -160,13 +316,26 @@ filesToModify:
       # Each pattern must contain a {%version%} placeholder
       - '"version": "{%version%}"'
     reportUnmatched: true
+
 releaseOptions:
   commitMessage: '[RELEASE] Release of my-fancy-library {%version%}'
   overwriteExistingTag: true
   signTag: true
   tagName: 'v{%version%}'
+
 # Relative (to config file) or absolute path to project root
 rootPath: ../
+
+versionRangeIndicators:
+  - range: major
+    strategy: matchAll
+    patterns:
+      - type: fileDeleted
+        pattern: '/^src\/Controller\/.+Controller\.php$/'
+      - type: fileModified
+        pattern: '/^res\/api\.schema\.json$/'
+      - type: commitMessage
+        pattern: '/^\[!!!]/'
 ```
 
 > [!TIP]
@@ -176,9 +345,9 @@ rootPath: ../
 
 | Property                          | Type             | Required | Description                                                                                                                                                                                                                                                                       |
 |-----------------------------------|------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `filesToModify`                   | Array of Objects | ✅        | List of files that contain versions which are to be bumped.                                                                                                                                                                                                                       |
+| `filesToModify`                   | Array of objects | ✅        | List of files that contain versions which are to be bumped.                                                                                                                                                                                                                       |
 | `filesToModify.*.path`            | String           | ✅        | Relative or absolute path to the file. Relative paths are calculated from the configured (or calculated) project root.                                                                                                                                                            |
-| `filesToModify.*.patterns`        | Array of Strings | ✅        | List of version patterns to be searched and replaced in the configured file. Each pattern must contain a `{%version%}` placeholder that is replaced by the new version. Patterns are internally converted to regular expressions, so feel free to use regex syntax such as `\s+`. |
+| `filesToModify.*.patterns`        | Array of strings | ✅        | List of version patterns to be searched and replaced in the configured file. Each pattern must contain a `{%version%}` placeholder that is replaced by the new version. Patterns are internally converted to regular expressions, so feel free to use regex syntax such as `\s+`. |
 | `filesToModify.*.reportUnmatched` | Boolean          | –        | Show warning if a configured pattern does not match file contents. Useful in combination with the `--strict` command option.                                                                                                                                                      |
 
 #### Release options
@@ -196,6 +365,17 @@ rootPath: ../
 | Property   | Type   | Required | Description                                                                                                                                                                                                                                         |
 |------------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `rootPath` | String | –        | Relative or absolute path to project root. This path will be used to calculate paths to configured files if they are configured as relative paths. If the root path is configured as relative path, it is calculated based on the config file path. |
+
+#### Version range indicators
+
+| Property                                      | Type             | Required | Description                                                                                         |
+|-----------------------------------------------|------------------|----------|-----------------------------------------------------------------------------------------------------|
+| `versionRangeIndicators`                      | Array of objects | –        | List of indicators to auto-detect a version range to be bumped.                                     |
+| `versionRangeIndicators.*.patterns`           | Array of objects | ✅        | List of version range patterns to match for this indicator.                                         |
+| `versionRangeIndicators.*.patterns.*.pattern` | String           | ✅        | Regular expression to match a specific version range indicator.                                     |
+| `versionRangeIndicators.*.patterns.*.type`    | String (enum)    | ✅        | Type of the pattern to match, can be `commitMessage`, `fileAdded`, `fileDeleted` or `fileModified`. |
+| `versionRangeIndicators.*.range`              | String (enum)    | ✅        | Version range to use when patterns match, can be `major`, `minor`, `next` or `patch`.               |
+| `versionRangeIndicators.*.strategy`           | String (enum)    | –        | Match strategy for configured patterns, can be `matchAll`, `matchAny` (default) or `matchNone`.     |
 
 ### Configuration in `composer.json`
 

--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -17,6 +17,13 @@
 			"type": "string",
 			"title": "Relative or absolute path to project root",
 			"description": "This path will be used to calculate paths to configured files if they are configured as relative paths. If the root path is configured as relative path, it is calculated based on the config file path."
+		},
+		"versionRangeIndicators": {
+			"type": "array",
+			"title": "List of indicators to automatically determine version range",
+			"items": {
+				"$ref": "#/definitions/versionRangeIndicator"
+			}
 		}
 	},
 	"additionalProperties": false,
@@ -76,11 +83,77 @@
 					"description": "Must contain a `{%version%}` placeholder that is replaced by the version to release.",
 					"$ref": "#/definitions/versionPattern"
 				}
-			}
+			},
+			"additionalProperties": false
 		},
 		"versionPattern": {
 			"type": "string",
 			"pattern": "\\{%version%\\}"
+		},
+		"versionRange": {
+			"type": "string",
+			"enum": [
+				"major",
+				"minor",
+				"next",
+				"patch"
+			]
+		},
+		"versionRangeIndicator": {
+			"type": "object",
+			"title": "Indicator to use a specific version range for the new version to bump",
+			"properties": {
+				"patterns": {
+					"type": "array",
+					"title": "List of version range patterns to match for this indicator",
+					"items": {
+						"$ref": "#/definitions/versionRangePattern"
+					}
+				},
+				"range": {
+					"$ref": "#/definitions/versionRange"
+				},
+				"strategy": {
+					"type": "string",
+					"title": "Match strategy for configured patterns",
+					"enum": [
+						"matchAll",
+						"matchAny",
+						"matchNone"
+					],
+					"default": "matchAny"
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"patterns",
+				"range"
+			]
+		},
+		"versionRangePattern": {
+			"type": "object",
+			"title": "Pattern to indicate a specific version range",
+			"properties": {
+				"pattern": {
+					"type": "string",
+					"title": "Regular expression to match a specific version range indicator"
+				},
+				"type": {
+					"type": "string",
+					"title": "Type of the pattern to match",
+					"enum": [
+						"commitMessage",
+						"fileAdded",
+						"fileDeleted",
+						"fileModified"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"pattern",
+				"type"
+			]
 		}
 	}
 }

--- a/src/Config/VersionRangeIndicator.php
+++ b/src/Config/VersionRangeIndicator.php
@@ -23,55 +23,40 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\VersionBumper\Config;
 
+use EliasHaeussler\VersionBumper\Enum;
+
 /**
- * VersionBumperConfig.
+ * VersionRangeIndicator.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class VersionBumperConfig
+final class VersionRangeIndicator
 {
     /**
-     * @param list<FileToModify>          $filesToModify
-     * @param list<VersionRangeIndicator> $versionRangeIndicators
+     * @param list<VersionRangePattern> $patterns
      */
     public function __construct(
-        private readonly array $filesToModify = [],
-        private ?string $rootPath = null,
-        private readonly ReleaseOptions $releaseOptions = new ReleaseOptions(),
-        private readonly array $versionRangeIndicators = [],
+        private readonly Enum\VersionRange $range,
+        private readonly array $patterns,
+        private readonly Enum\VersionRangeIndicatorStrategy $strategy = Enum\VersionRangeIndicatorStrategy::MatchAny,
     ) {}
 
-    /**
-     * @return list<FileToModify>
-     */
-    public function filesToModify(): array
+    public function range(): Enum\VersionRange
     {
-        return $this->filesToModify;
-    }
-
-    public function rootPath(): ?string
-    {
-        return $this->rootPath;
-    }
-
-    public function setRootPath(string $rootPath): self
-    {
-        $this->rootPath = $rootPath;
-
-        return $this;
-    }
-
-    public function releaseOptions(): ReleaseOptions
-    {
-        return $this->releaseOptions;
+        return $this->range;
     }
 
     /**
-     * @return list<VersionRangeIndicator>
+     * @return list<VersionRangePattern>
      */
-    public function versionRangeIndicators(): array
+    public function patterns(): array
     {
-        return $this->versionRangeIndicators;
+        return $this->patterns;
+    }
+
+    public function strategy(): Enum\VersionRangeIndicatorStrategy
+    {
+        return $this->strategy;
     }
 }

--- a/src/Config/VersionRangePattern.php
+++ b/src/Config/VersionRangePattern.php
@@ -23,55 +23,28 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\VersionBumper\Config;
 
+use EliasHaeussler\VersionBumper\Enum;
+
 /**
- * VersionBumperConfig.
+ * VersionRangePattern.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class VersionBumperConfig
+final class VersionRangePattern
 {
-    /**
-     * @param list<FileToModify>          $filesToModify
-     * @param list<VersionRangeIndicator> $versionRangeIndicators
-     */
     public function __construct(
-        private readonly array $filesToModify = [],
-        private ?string $rootPath = null,
-        private readonly ReleaseOptions $releaseOptions = new ReleaseOptions(),
-        private readonly array $versionRangeIndicators = [],
+        private readonly Enum\VersionRangeIndicatorType $type,
+        private readonly string $pattern,
     ) {}
 
-    /**
-     * @return list<FileToModify>
-     */
-    public function filesToModify(): array
+    public function type(): Enum\VersionRangeIndicatorType
     {
-        return $this->filesToModify;
+        return $this->type;
     }
 
-    public function rootPath(): ?string
+    public function pattern(): string
     {
-        return $this->rootPath;
-    }
-
-    public function setRootPath(string $rootPath): self
-    {
-        $this->rootPath = $rootPath;
-
-        return $this;
-    }
-
-    public function releaseOptions(): ReleaseOptions
-    {
-        return $this->releaseOptions;
-    }
-
-    /**
-     * @return list<VersionRangeIndicator>
-     */
-    public function versionRangeIndicators(): array
-    {
-        return $this->versionRangeIndicators;
+        return $this->pattern;
     }
 }

--- a/src/Enum/VersionRange.php
+++ b/src/Enum/VersionRange.php
@@ -25,9 +25,11 @@ namespace EliasHaeussler\VersionBumper\Enum;
 
 use EliasHaeussler\VersionBumper\Exception;
 
+use function array_pop;
 use function array_search;
 use function in_array;
 use function strtolower;
+use function usort;
 
 /**
  * VersionRange.
@@ -89,5 +91,25 @@ enum VersionRange: string
         }
 
         return $all;
+    }
+
+    public static function getHighest(self ...$ranges): ?self
+    {
+        if ([] === $ranges) {
+            return null;
+        }
+
+        usort($ranges, static fn (self $a, self $b) => $a->getPriority() <=> $b->getPriority());
+
+        return array_pop($ranges);
+    }
+
+    private function getPriority(): int
+    {
+        return match ($this) {
+            self::Major => 3,
+            self::Minor => 2,
+            self::Patch, self::Next => 1,
+        };
     }
 }

--- a/src/Enum/VersionRangeIndicatorStrategy.php
+++ b/src/Enum/VersionRangeIndicatorStrategy.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Enum;
+
+/**
+ * VersionRangeIndicatorStrategy.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+enum VersionRangeIndicatorStrategy: string
+{
+    case MatchAll = 'matchAll';
+    case MatchAny = 'matchAny';
+    case MatchNone = 'matchNone';
+}

--- a/src/Enum/VersionRangeIndicatorType.php
+++ b/src/Enum/VersionRangeIndicatorType.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Enum;
+
+use GitElephant\Objects;
+
+/**
+ * VersionRangeIndicatorType.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+enum VersionRangeIndicatorType: string
+{
+    case CommitMessage = 'commitMessage';
+    case FileAdded = 'fileAdded';
+    case FileDeleted = 'fileDeleted';
+    case FileModified = 'fileModified';
+
+    /**
+     * @param Objects\Diff\DiffObject::MODE_* $mode
+     */
+    public static function fromDiffMode(string $mode): self
+    {
+        return match ($mode) {
+            Objects\Diff\DiffObject::MODE_DELETED_FILE => self::FileDeleted,
+            Objects\Diff\DiffObject::MODE_NEW_FILE => self::FileAdded,
+            default => self::FileModified,
+        };
+    }
+}

--- a/src/Exception/CannotFetchGitCommits.php
+++ b/src/Exception/CannotFetchGitCommits.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Exception;
+
+use function sprintf;
+
+/**
+ * CannotFetchGitCommits.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class CannotFetchGitCommits extends Exception
+{
+    public function __construct(string $diff)
+    {
+        parent::__construct(
+            sprintf('Unable to fetch Git commits between "%s" from repository.', $diff),
+            1731358503,
+        );
+    }
+}

--- a/src/Exception/CannotFetchGitTag.php
+++ b/src/Exception/CannotFetchGitTag.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Exception;
+
+use function sprintf;
+
+/**
+ * CannotFetchGitTag.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class CannotFetchGitTag extends Exception
+{
+    public function __construct(string $tag)
+    {
+        parent::__construct(
+            sprintf('Unable to fetch Git tag "%s" from repository.', $tag),
+            1731358122,
+        );
+    }
+}

--- a/src/Exception/CannotFetchLatestGitTag.php
+++ b/src/Exception/CannotFetchLatestGitTag.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Exception;
+
+/**
+ * CannotFetchLatestGitTag.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class CannotFetchLatestGitTag extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'Unable to fetch latest Git tag from repository.',
+            1731357818,
+        );
+    }
+}

--- a/src/Exception/GitTagDoesNotExist.php
+++ b/src/Exception/GitTagDoesNotExist.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Exception;
+
+use function sprintf;
+
+/**
+ * GitTagDoesNotExist.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class GitTagDoesNotExist extends Exception
+{
+    public function __construct(string $tag)
+    {
+        parent::__construct(
+            sprintf('Git tag "%s" does not exist.', $tag),
+            1731358186,
+        );
+    }
+}

--- a/src/Exception/NoGitTagsFound.php
+++ b/src/Exception/NoGitTagsFound.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Exception;
+
+/**
+ * NoGitTagsFound.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class NoGitTagsFound extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'Could not find any Git tags in the repository.',
+            1731357319,
+        );
+    }
+}

--- a/src/Helper/VersionHelper.php
+++ b/src/Helper/VersionHelper.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\VersionBumper\Helper;
 use EliasHaeussler\VersionBumper\Version;
 
 use function addcslashes;
+use function preg_match;
 use function str_contains;
 use function str_replace;
 
@@ -40,7 +41,12 @@ use function str_replace;
 final class VersionHelper
 {
     private const VERSION_PLACEHOLDER = '{%version%}';
-    private const VERSION_REGEX = '(?P<version>\\d+\\.\\d+\\.\\d+)';
+    private const VERSION_REGEX = '(?P<version>v?\\d+\\.\\d+\\.\\d+)';
+
+    public static function isValidVersion(string $version): bool
+    {
+        return 1 === preg_match('/^'.self::VERSION_REGEX.'$/', $version);
+    }
 
     public static function isValidVersionPattern(string $pattern): bool
     {

--- a/src/Version/RangeDetection/CommitMessagesRangeDetection.php
+++ b/src/Version/RangeDetection/CommitMessagesRangeDetection.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Version\RangeDetection;
+
+use EliasHaeussler\VersionBumper\Config;
+use EliasHaeussler\VersionBumper\Enum;
+
+use function preg_match;
+
+/**
+ * CommitMessagesRangeDetection.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class CommitMessagesRangeDetection implements RangeDetection
+{
+    /**
+     * @param list<string> $commitMessages
+     */
+    public function __construct(
+        private readonly array $commitMessages,
+    ) {}
+
+    public function matches(Config\VersionRangePattern $pattern): bool
+    {
+        foreach ($this->commitMessages as $commitMessage) {
+            if (1 === preg_match($pattern->pattern(), $commitMessage)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function supports(Config\VersionRangePattern $pattern): bool
+    {
+        return Enum\VersionRangeIndicatorType::CommitMessage === $pattern->type();
+    }
+}

--- a/src/Version/RangeDetection/DiffRangeDetection.php
+++ b/src/Version/RangeDetection/DiffRangeDetection.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Version\RangeDetection;
+
+use EliasHaeussler\VersionBumper\Config;
+use EliasHaeussler\VersionBumper\Enum;
+use GitElephant\Objects;
+
+use function preg_match;
+
+/**
+ * DiffRangeDetection.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class DiffRangeDetection implements RangeDetection
+{
+    public function __construct(
+        private readonly Objects\Diff\Diff $diff,
+    ) {}
+
+    public function matches(Config\VersionRangePattern $pattern): bool
+    {
+        /** @var Objects\Diff\DiffObject $diffObject */
+        foreach ($this->diff as $diffObject) {
+            $type = $this->getTypeFromDiffObject($diffObject);
+            $path = $diffObject->getOriginalPath();
+
+            if ($type !== $pattern->type()) {
+                continue;
+            }
+
+            if (1 === preg_match($pattern->pattern(), $path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function supports(Config\VersionRangePattern $pattern): bool
+    {
+        /** @var Objects\Diff\DiffObject $diffObject */
+        foreach ($this->diff as $diffObject) {
+            $type = $this->getTypeFromDiffObject($diffObject);
+
+            if ($type === $pattern->type()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getTypeFromDiffObject(Objects\Diff\DiffObject $diffObject): Enum\VersionRangeIndicatorType
+    {
+        /** @var Objects\Diff\DiffObject::MODE_* $mode */
+        $mode = $diffObject->getMode();
+
+        return Enum\VersionRangeIndicatorType::fromDiffMode($mode);
+    }
+}

--- a/src/Version/RangeDetection/RangeDetection.php
+++ b/src/Version/RangeDetection/RangeDetection.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Version\RangeDetection;
+
+use EliasHaeussler\VersionBumper\Config;
+
+/**
+ * RangeDetection.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+interface RangeDetection
+{
+    public function matches(Config\VersionRangePattern $pattern): bool;
+
+    public function supports(Config\VersionRangePattern $pattern): bool;
+}

--- a/src/Version/Version.php
+++ b/src/Version/Version.php
@@ -37,7 +37,7 @@ use function preg_match;
  */
 final class Version implements Stringable
 {
-    private const VERSION_PATTERN = '/^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$/';
+    private const VERSION_PATTERN = '/^v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$/';
 
     public function __construct(
         private readonly int $major,

--- a/src/Version/VersionRangeDetector.php
+++ b/src/Version/VersionRangeDetector.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Version;
+
+use EliasHaeussler\VersionBumper\Config;
+use EliasHaeussler\VersionBumper\Enum;
+use EliasHaeussler\VersionBumper\Exception;
+use EliasHaeussler\VersionBumper\Helper;
+use GitElephant\Command;
+use GitElephant\Objects;
+use GitElephant\Repository;
+
+use function array_filter;
+use function array_map;
+use function array_pop;
+use function array_values;
+use function iterator_to_array;
+use function sprintf;
+use function usort;
+use function version_compare;
+
+/**
+ * VersionRangeDetector.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class VersionRangeDetector
+{
+    public function __construct(
+        private readonly ?Command\Caller\CallerInterface $caller = null,
+    ) {}
+
+    /**
+     * @param list<Config\VersionRangeIndicator> $indicators
+     *
+     * @throws Exception\CannotFetchGitCommits
+     * @throws Exception\CannotFetchGitTag
+     * @throws Exception\CannotFetchLatestGitTag
+     * @throws Exception\GitTagDoesNotExist
+     * @throws Exception\NoGitTagsFound
+     */
+    public function detect(string $rootPath, array $indicators, ?string $since = null): ?Enum\VersionRange
+    {
+        $repository = new Repository($rootPath);
+        $detectedRanges = [];
+
+        // Inject custom repository caller
+        if (null !== $this->caller) {
+            $repository->setCaller($this->caller);
+        }
+
+        // Fetch tag used for comparison
+        if (null !== $since) {
+            $tag = $this->fetchTag($since, $repository) ?? throw new Exception\GitTagDoesNotExist($since);
+        } else {
+            $tag = $this->fetchLatestVersionTag($repository) ?? throw new Exception\NoGitTagsFound();
+        }
+
+        // Fetch relevant Git information
+        $commitMessages = $this->fetchCommitMessages($tag, $repository);
+        $diff = $repository->getDiff($tag->getName());
+
+        $detectors = [
+            new RangeDetection\CommitMessagesRangeDetection($commitMessages),
+            new RangeDetection\DiffRangeDetection($diff),
+        ];
+
+        foreach ($indicators as $indicator) {
+            $matchedRangeDetections = 0;
+            $unmatchedRangeDetections = 0;
+
+            // Evaluate all configured patterns
+            foreach ($indicator->patterns() as $pattern) {
+                foreach ($detectors as $detector) {
+                    if (!$detector->supports($pattern)) {
+                        continue;
+                    }
+
+                    if ($detector->matches($pattern)) {
+                        ++$matchedRangeDetections;
+                    } else {
+                        ++$unmatchedRangeDetections;
+                    }
+                }
+            }
+
+            // Evaluate matched detections against configured strategy
+            $indicatorMatches = match ($indicator->strategy()) {
+                Enum\VersionRangeIndicatorStrategy::MatchAll => 0 === $unmatchedRangeDetections,
+                Enum\VersionRangeIndicatorStrategy::MatchAny => $matchedRangeDetections > 0,
+                Enum\VersionRangeIndicatorStrategy::MatchNone => 0 === $matchedRangeDetections,
+            };
+
+            // Add range if indicator matches
+            if ($indicatorMatches) {
+                $detectedRanges[] = $indicator->range();
+            }
+        }
+
+        if ([] !== $detectedRanges) {
+            return Enum\VersionRange::getHighest(...$detectedRanges);
+        }
+
+        return null;
+    }
+
+    /**
+     * @throws Exception\CannotFetchGitTag
+     */
+    private function fetchTag(string $tagName, Repository $repository): ?Objects\Tag
+    {
+        try {
+            return $repository->getTag($tagName);
+        } catch (\Exception) {
+            throw new Exception\CannotFetchGitTag($tagName);
+        }
+    }
+
+    /**
+     * @throws Exception\CannotFetchLatestGitTag
+     */
+    private function fetchLatestVersionTag(Repository $repository): ?Objects\Tag
+    {
+        try {
+            $tags = $repository->getTags();
+        } catch (\Exception) {
+            throw new Exception\CannotFetchLatestGitTag();
+        }
+
+        // Drop all non-version tags
+        $tags = array_filter(
+            $tags,
+            static fn (Objects\Tag $tag) => Helper\VersionHelper::isValidVersion($tag->getName()),
+        );
+
+        // Early return if no version tags are left
+        if ([] === $tags) {
+            return null;
+        }
+
+        // Sort version tags by descending version number
+        usort(
+            $tags,
+            static function (Objects\Tag $a, Objects\Tag $b) {
+                $a = Version::fromFullVersion($a->getName());
+                $b = Version::fromFullVersion($b->getName());
+
+                return version_compare($a->full(), $b->full());
+            },
+        );
+
+        return array_pop($tags);
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @throws Exception\CannotFetchGitCommits
+     */
+    private function fetchCommitMessages(Objects\Tag $tag, Repository $repository): array
+    {
+        $diff = sprintf('%s..HEAD', $tag->getName());
+
+        try {
+            $logRange = $repository->getLogRange($tag->getFullRef(), 'HEAD', null, -1, 0);
+        } catch (\Exception) {
+            throw new Exception\CannotFetchGitCommits($diff);
+        }
+
+        return array_values(
+            array_filter(
+                array_map(
+                    static fn (?Objects\Commit $commit) => $commit?->getMessage()?->getShortMessage(),
+                    iterator_to_array($logRange),
+                ),
+                static fn (?string $message) => null !== $message,
+            ),
+        );
+    }
+}

--- a/tests/src/Enum/VersionRangeIndicatorTypeTest.php
+++ b/tests/src/Enum/VersionRangeIndicatorTypeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Enum;
+
+use EliasHaeussler\VersionBumper as Src;
+use Generator;
+use GitElephant\Objects;
+use PHPUnit\Framework;
+
+/**
+ * VersionRangeIndicatorTypeTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Enum\VersionRangeIndicatorType::class)]
+final class VersionRangeIndicatorTypeTest extends Framework\TestCase
+{
+    /**
+     * @return Generator<string, array{Objects\Diff\DiffObject::MODE_*, Src\Enum\VersionRangeIndicatorType}>
+     */
+    public static function fromDiffModeReturnsTypeForGivenModeDataProvider(): Generator
+    {
+        yield 'deleted file' => [Objects\Diff\DiffObject::MODE_DELETED_FILE, Src\Enum\VersionRangeIndicatorType::FileDeleted];
+        yield 'added file' => [Objects\Diff\DiffObject::MODE_NEW_FILE, Src\Enum\VersionRangeIndicatorType::FileAdded];
+        yield 'modified file (mode)' => [Objects\Diff\DiffObject::MODE_MODE, Src\Enum\VersionRangeIndicatorType::FileModified];
+        yield 'modified file (index)' => [Objects\Diff\DiffObject::MODE_INDEX, Src\Enum\VersionRangeIndicatorType::FileModified];
+        yield 'modified file (renamed)' => [Objects\Diff\DiffObject::MODE_RENAMED, Src\Enum\VersionRangeIndicatorType::FileModified];
+    }
+
+    /**
+     * @param Objects\Diff\DiffObject::MODE_* $mode
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('fromDiffModeReturnsTypeForGivenModeDataProvider')]
+    public function fromDiffModeReturnsTypeForGivenMode(
+        string $mode,
+        Src\Enum\VersionRangeIndicatorType $expected,
+    ): void {
+        self::assertSame($expected, Src\Enum\VersionRangeIndicatorType::fromDiffMode($mode));
+    }
+}

--- a/tests/src/Enum/VersionRangeTest.php
+++ b/tests/src/Enum/VersionRangeTest.php
@@ -89,6 +89,24 @@ final class VersionRangeTest extends Framework\TestCase
         self::assertSame($expected, Src\Enum\VersionRange::all());
     }
 
+    #[Framework\Attributes\Test]
+    public function getHighesReturnsEmptyArrayIfNoVersionRangesAreGiven(): void
+    {
+        self::assertNull(Src\Enum\VersionRange::getHighest());
+    }
+
+    /**
+     * @param list<Src\Enum\VersionRange> $ranges
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('getHighestReturnsVersionRangeWithHighestPriorityDataProvider')]
+    public function getHighestReturnsVersionRangeWithHighestPriority(
+        array $ranges,
+        Src\Enum\VersionRange $expected,
+    ): void {
+        self::assertSame($expected, Src\Enum\VersionRange::getHighest(...$ranges));
+    }
+
     /**
      * @return Generator<string, array{string, Src\Enum\VersionRange}>
      */
@@ -109,5 +127,21 @@ final class VersionRangeTest extends Framework\TestCase
         yield 'minor' => ['minor', Src\Enum\VersionRange::Minor];
         yield 'next' => ['next', Src\Enum\VersionRange::Next];
         yield 'patch' => ['patch', Src\Enum\VersionRange::Patch];
+    }
+
+    /**
+     * @return Generator<string, array{list<Src\Enum\VersionRange>, Src\Enum\VersionRange}>
+     */
+    public static function getHighestReturnsVersionRangeWithHighestPriorityDataProvider(): Generator
+    {
+        $major = Src\Enum\VersionRange::Major;
+        $minor = Src\Enum\VersionRange::Minor;
+        $next = Src\Enum\VersionRange::Next;
+        $patch = Src\Enum\VersionRange::Patch;
+
+        yield 'major' => [[$next, $major, $patch, $minor], $major];
+        yield 'minor' => [[$next, $minor, $patch], $minor];
+        yield 'next' => [[$next, $patch, $next], $next];
+        yield 'patch' => [[$next, $next, $patch], $patch];
     }
 }

--- a/tests/src/Exception/CannotFetchGitCommitsTest.php
+++ b/tests/src/Exception/CannotFetchGitCommitsTest.php
@@ -21,41 +21,26 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\VersionBumper\Tests\Config;
+namespace EliasHaeussler\VersionBumper\Tests\Exception;
 
 use EliasHaeussler\VersionBumper as Src;
 use PHPUnit\Framework;
 
 /**
- * FilePatternTest.
+ * CannotFetchGitCommitsTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Framework\Attributes\CoversClass(Src\Config\FilePattern::class)]
-final class FilePatternTest extends Framework\TestCase
+#[Framework\Attributes\CoversClass(Src\Exception\CannotFetchGitCommits::class)]
+final class CannotFetchGitCommitsTest extends Framework\TestCase
 {
-    private Src\Config\FilePattern $subject;
-
-    public function setUp(): void
-    {
-        $this->subject = new Src\Config\FilePattern('foo/foo: {%version%}');
-    }
-
     #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfVersionPlaceholderIsMissing(): void
+    public function constructorCreatesExceptionForGivenDiff(): void
     {
-        $this->expectExceptionObject(
-            new Src\Exception\FilePatternIsInvalid('foo'),
-        );
+        $actual = new Src\Exception\CannotFetchGitCommits('foo..baz');
 
-        new Src\Config\FilePattern('foo');
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorConvertsPatternToRegularExpression(): void
-    {
-        self::assertSame('foo/foo: {%version%}', $this->subject->original());
-        self::assertSame('/foo\/foo: (?P<version>v?\d+\.\d+\.\d+)/', $this->subject->regularExpression());
+        self::assertSame('Unable to fetch Git commits between "foo..baz" from repository.', $actual->getMessage());
+        self::assertSame(1731358503, $actual->getCode());
     }
 }

--- a/tests/src/Exception/CannotFetchGitTagTest.php
+++ b/tests/src/Exception/CannotFetchGitTagTest.php
@@ -21,41 +21,26 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\VersionBumper\Tests\Config;
+namespace EliasHaeussler\VersionBumper\Tests\Exception;
 
 use EliasHaeussler\VersionBumper as Src;
 use PHPUnit\Framework;
 
 /**
- * FilePatternTest.
+ * CannotFetchGitTagTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Framework\Attributes\CoversClass(Src\Config\FilePattern::class)]
-final class FilePatternTest extends Framework\TestCase
+#[Framework\Attributes\CoversClass(Src\Exception\CannotFetchGitTag::class)]
+final class CannotFetchGitTagTest extends Framework\TestCase
 {
-    private Src\Config\FilePattern $subject;
-
-    public function setUp(): void
-    {
-        $this->subject = new Src\Config\FilePattern('foo/foo: {%version%}');
-    }
-
     #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfVersionPlaceholderIsMissing(): void
+    public function constructorCreatesExceptionForGivenTag(): void
     {
-        $this->expectExceptionObject(
-            new Src\Exception\FilePatternIsInvalid('foo'),
-        );
+        $actual = new Src\Exception\CannotFetchGitTag('foo');
 
-        new Src\Config\FilePattern('foo');
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorConvertsPatternToRegularExpression(): void
-    {
-        self::assertSame('foo/foo: {%version%}', $this->subject->original());
-        self::assertSame('/foo\/foo: (?P<version>v?\d+\.\d+\.\d+)/', $this->subject->regularExpression());
+        self::assertSame('Unable to fetch Git tag "foo" from repository.', $actual->getMessage());
+        self::assertSame(1731358122, $actual->getCode());
     }
 }

--- a/tests/src/Exception/CannotFetchLatestGitTagTest.php
+++ b/tests/src/Exception/CannotFetchLatestGitTagTest.php
@@ -21,41 +21,26 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\VersionBumper\Tests\Config;
+namespace EliasHaeussler\VersionBumper\Tests\Exception;
 
 use EliasHaeussler\VersionBumper as Src;
 use PHPUnit\Framework;
 
 /**
- * FilePatternTest.
+ * CannotFetchLatestGitTagTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Framework\Attributes\CoversClass(Src\Config\FilePattern::class)]
-final class FilePatternTest extends Framework\TestCase
+#[Framework\Attributes\CoversClass(Src\Exception\CannotFetchLatestGitTag::class)]
+final class CannotFetchLatestGitTagTest extends Framework\TestCase
 {
-    private Src\Config\FilePattern $subject;
-
-    public function setUp(): void
-    {
-        $this->subject = new Src\Config\FilePattern('foo/foo: {%version%}');
-    }
-
     #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfVersionPlaceholderIsMissing(): void
+    public function constructorCreatesException(): void
     {
-        $this->expectExceptionObject(
-            new Src\Exception\FilePatternIsInvalid('foo'),
-        );
+        $actual = new Src\Exception\CannotFetchLatestGitTag();
 
-        new Src\Config\FilePattern('foo');
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorConvertsPatternToRegularExpression(): void
-    {
-        self::assertSame('foo/foo: {%version%}', $this->subject->original());
-        self::assertSame('/foo\/foo: (?P<version>v?\d+\.\d+\.\d+)/', $this->subject->regularExpression());
+        self::assertSame('Unable to fetch latest Git tag from repository.', $actual->getMessage());
+        self::assertSame(1731357818, $actual->getCode());
     }
 }

--- a/tests/src/Exception/GitTagDoesNotExistTest.php
+++ b/tests/src/Exception/GitTagDoesNotExistTest.php
@@ -21,41 +21,26 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\VersionBumper\Tests\Config;
+namespace EliasHaeussler\VersionBumper\Tests\Exception;
 
 use EliasHaeussler\VersionBumper as Src;
 use PHPUnit\Framework;
 
 /**
- * FilePatternTest.
+ * GitTagDoesNotExistTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Framework\Attributes\CoversClass(Src\Config\FilePattern::class)]
-final class FilePatternTest extends Framework\TestCase
+#[Framework\Attributes\CoversClass(Src\Exception\GitTagDoesNotExist::class)]
+final class GitTagDoesNotExistTest extends Framework\TestCase
 {
-    private Src\Config\FilePattern $subject;
-
-    public function setUp(): void
-    {
-        $this->subject = new Src\Config\FilePattern('foo/foo: {%version%}');
-    }
-
     #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfVersionPlaceholderIsMissing(): void
+    public function constructorCreatesExceptionForGivenTag(): void
     {
-        $this->expectExceptionObject(
-            new Src\Exception\FilePatternIsInvalid('foo'),
-        );
+        $actual = new Src\Exception\GitTagDoesNotExist('foo');
 
-        new Src\Config\FilePattern('foo');
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorConvertsPatternToRegularExpression(): void
-    {
-        self::assertSame('foo/foo: {%version%}', $this->subject->original());
-        self::assertSame('/foo\/foo: (?P<version>v?\d+\.\d+\.\d+)/', $this->subject->regularExpression());
+        self::assertSame('Git tag "foo" does not exist.', $actual->getMessage());
+        self::assertSame(1731358186, $actual->getCode());
     }
 }

--- a/tests/src/Exception/NoGitTagsFoundTest.php
+++ b/tests/src/Exception/NoGitTagsFoundTest.php
@@ -21,41 +21,26 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\VersionBumper\Tests\Config;
+namespace EliasHaeussler\VersionBumper\Tests\Exception;
 
 use EliasHaeussler\VersionBumper as Src;
 use PHPUnit\Framework;
 
 /**
- * FilePatternTest.
+ * NoGitTagsFoundTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-#[Framework\Attributes\CoversClass(Src\Config\FilePattern::class)]
-final class FilePatternTest extends Framework\TestCase
+#[Framework\Attributes\CoversClass(Src\Exception\NoGitTagsFound::class)]
+final class NoGitTagsFoundTest extends Framework\TestCase
 {
-    private Src\Config\FilePattern $subject;
-
-    public function setUp(): void
-    {
-        $this->subject = new Src\Config\FilePattern('foo/foo: {%version%}');
-    }
-
     #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfVersionPlaceholderIsMissing(): void
+    public function constructorCreatesException(): void
     {
-        $this->expectExceptionObject(
-            new Src\Exception\FilePatternIsInvalid('foo'),
-        );
+        $actual = new Src\Exception\NoGitTagsFound();
 
-        new Src\Config\FilePattern('foo');
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorConvertsPatternToRegularExpression(): void
-    {
-        self::assertSame('foo/foo: {%version%}', $this->subject->original());
-        self::assertSame('/foo\/foo: (?P<version>v?\d+\.\d+\.\d+)/', $this->subject->regularExpression());
+        self::assertSame('Could not find any Git tags in the repository.', $actual->getMessage());
+        self::assertSame(1731357319, $actual->getCode());
     }
 }

--- a/tests/src/Fixtures/Classes/DummyCaller.php
+++ b/tests/src/Fixtures/Classes/DummyCaller.php
@@ -25,8 +25,11 @@ namespace EliasHaeussler\VersionBumper\Tests\Fixtures\Classes;
 
 use GitElephant\Command;
 use PHPUnit\Framework\Assert;
+use Throwable;
 
+use function array_map;
 use function array_shift;
+use function explode;
 use function sprintf;
 
 /**
@@ -38,7 +41,7 @@ use function sprintf;
 final class DummyCaller extends Command\Caller\AbstractCaller
 {
     /**
-     * @var list<array{string, string}>
+     * @var list<array{string|Throwable, string}>
      */
     public array $results = [];
 
@@ -47,6 +50,8 @@ final class DummyCaller extends Command\Caller\AbstractCaller
         $result = array_shift($this->results);
 
         if (null === $result) {
+            $this->resetOutput();
+
             return $this;
         }
 
@@ -58,9 +63,19 @@ final class DummyCaller extends Command\Caller\AbstractCaller
             );
         }
 
+        if ($result instanceof Throwable) {
+            throw $result;
+        }
+
         $this->rawOutput = $result;
-        $this->outputLines = [$result];
+        $this->outputLines = array_map('rtrim', explode(PHP_EOL, $result));
 
         return $this;
+    }
+
+    public function resetOutput(): void
+    {
+        $this->rawOutput = '';
+        $this->outputLines = [];
     }
 }

--- a/tests/src/Fixtures/ConfigFiles/valid-config-with-indicators.json
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-with-indicators.json
@@ -1,0 +1,22 @@
+{
+	"filesToModify": [
+		{
+			"path": "tests/src/Fixtures/RootPath/foo",
+			"patterns": [
+				"baz: {%version%}"
+			]
+		}
+	],
+	"rootPath": "../../../..",
+	"versionRangeIndicators": [
+		{
+			"range": "major",
+			"patterns": [
+				{
+					"type": "fileAdded",
+					"pattern": "/.+/"
+				}
+			]
+		}
+	]
+}

--- a/tests/src/Fixtures/Git/diff-tag-added.txt
+++ b/tests/src/Fixtures/Git/diff-tag-added.txt
@@ -1,0 +1,7 @@
+diff --git SRC/README.md DST/README.md
+new file mode 100644
+index b3f88084d8be1732e160b2efdee3b962290d63ba..6aaffee163c083d2f45d29f02d4445fbf3aa1d06
+--- /dev/null
++++ DST/README.md
+@@ -0,0 +1 @@
++# Hello World!

--- a/tests/src/Fixtures/Git/diff-tag-deleted.txt
+++ b/tests/src/Fixtures/Git/diff-tag-deleted.txt
@@ -1,0 +1,7 @@
+diff --git SRC/README.md DST/README.md
+deleted file mode 100644
+index cc0be1e56dcbe29142bf4b97265a19afa1698e44..0000000000000000000000000000000000000000
+--- SRC/README.md
++++ /dev/null
+@@ -1 +0,0 @@
+-# Hello World!

--- a/tests/src/Fixtures/Git/log-commit.txt
+++ b/tests/src/Fixtures/Git/log-commit.txt
@@ -1,0 +1,7 @@
+commit 0b793c33883976589103ed147d17781a7e8a7b5d
+tree b72e584f7c5e29c52da54ad71824e4cb57ee86fe
+parent 70d8e62f5cd9d87c673de9bc2971f41194fdbc3b
+author Elias Häußler <elias@haeussler.dev> 1731684498 +0100
+committer Elias Häußler <elias@haeussler.dev> 1731689448 +0100
+
+    Hello World!

--- a/tests/src/Fixtures/Git/show-tag.txt
+++ b/tests/src/Fixtures/Git/show-tag.txt
@@ -1,0 +1,12 @@
+tag 1.2.0
+Tagger: Elias Häußler <elias@haeussler.dev>
+
+1.2.0
+
+commit 08708bc0b5c07a8233b6510c4677ad3ad112d5d4
+tree 0adc74bafebc6253e39e458d8bdb881b84fa814d
+parent 7050e7825a71f46db04c8575c9608b802b03ccbc
+author Elias Häußler <elias@haeussler.dev> 1727980384 +0200
+committer Elias Häußler <elias@haeussler.dev> 1727980384 +0200
+
+    Hello World!

--- a/tests/src/Helper/VersionHelperTest.php
+++ b/tests/src/Helper/VersionHelperTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\VersionBumper\Tests\Helper;
 
 use EliasHaeussler\VersionBumper as Src;
+use Generator;
 use PHPUnit\Framework;
 
 /**
@@ -36,6 +37,13 @@ use PHPUnit\Framework;
 final class VersionHelperTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('isValidVersionReturnsTrueIfGivenVersionIsValidDataProvider')]
+    public function isValidVersionReturnsTrueIfGivenVersionIsValid(string $version, bool $expected): void
+    {
+        self::assertSame($expected, Src\Helper\VersionHelper::isValidVersion($version));
+    }
+
+    #[Framework\Attributes\Test]
     public function isValidVersionPatternReturnsTrueIfPatternContainsVersionPlaceholder(): void
     {
         self::assertTrue(Src\Helper\VersionHelper::isValidVersionPattern('foo/foo: {%version%}'));
@@ -46,7 +54,7 @@ final class VersionHelperTest extends Framework\TestCase
     public function convertPatternToRegularExpressionConvertsPatternToRegularExpression(): void
     {
         self::assertSame(
-            '/foo\/foo: (?P<version>\d+\.\d+\.\d+)/',
+            '/foo\/foo: (?P<version>v?\d+\.\d+\.\d+)/',
             Src\Helper\VersionHelper::convertPatternToRegularExpression('foo/foo: {%version%}'),
         );
     }
@@ -60,5 +68,15 @@ final class VersionHelperTest extends Framework\TestCase
             'foo/foo: 1.2.3',
             Src\Helper\VersionHelper::replaceVersionInPattern('foo/foo: {%version%}', $version),
         );
+    }
+
+    /**
+     * @return Generator<string, array{string, bool}>
+     */
+    public static function isValidVersionReturnsTrueIfGivenVersionIsValidDataProvider(): Generator
+    {
+        yield 'valid version' => ['1.2.3', true];
+        yield 'valid version with prefix' => ['v1.2.3', true];
+        yield 'invalid version' => ['1.2.3-beta.1', false];
     }
 }

--- a/tests/src/Version/RangeDetection/CommitMessagesRangeDetectionTest.php
+++ b/tests/src/Version/RangeDetection/CommitMessagesRangeDetectionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Version\RangeDetection;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
+
+/**
+ * CommitMessagesRangeDetectionTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Version\RangeDetection\CommitMessagesRangeDetection::class)]
+final class CommitMessagesRangeDetectionTest extends Framework\TestCase
+{
+    private Src\Version\RangeDetection\CommitMessagesRangeDetection $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Version\RangeDetection\CommitMessagesRangeDetection([
+            '[!!!][TASK] Remove dashboard controller',
+            '[FEATURE] Add login controller',
+            '[DOCS] Mention login controller in developer docs',
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function matchesReturnsFalseIfNoCommitMessagesAreAvailable(): void
+    {
+        $pattern = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+            'foo',
+        );
+
+        $subject = new Src\Version\RangeDetection\CommitMessagesRangeDetection([]);
+
+        self::assertFalse($subject->matches($pattern));
+    }
+
+    #[Framework\Attributes\Test]
+    public function matchesReturnsTrueIfAnyCommitMessageMatchesGivenPattern(): void
+    {
+        $pattern = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+            '/^\[FEATURE]/',
+        );
+
+        self::assertTrue($this->subject->matches($pattern));
+    }
+
+    #[Framework\Attributes\Test]
+    public function matchesReturnsFalseIfNoCommitMessageMatchesGivenPattern(): void
+    {
+        $pattern = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+            '/^\[TASK]/',
+        );
+
+        self::assertFalse($this->subject->matches($pattern));
+    }
+
+    #[Framework\Attributes\Test]
+    public function supportsReturnsTrueIfGivenPatternHasCommitMessageTypeAssociated(): void
+    {
+        self::assertTrue(
+            $this->subject->supports(
+                new Src\Config\VersionRangePattern(
+                    Src\Enum\VersionRangeIndicatorType::CommitMessage,
+                    'foo',
+                ),
+            ),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function supportsReturnsFalseIfGivenPatternHasDifferentTypeThanCommitMessageAssociated(): void
+    {
+        self::assertFalse(
+            $this->subject->supports(
+                new Src\Config\VersionRangePattern(
+                    Src\Enum\VersionRangeIndicatorType::FileAdded,
+                    'foo',
+                ),
+            ),
+        );
+    }
+}

--- a/tests/src/Version/RangeDetection/DiffRangeDetectionTest.php
+++ b/tests/src/Version/RangeDetection/DiffRangeDetectionTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Version\RangeDetection;
+
+use EliasHaeussler\VersionBumper as Src;
+use GitElephant\Objects;
+use GitElephant\Repository;
+use PHPUnit\Framework;
+
+use function dirname;
+use function file_get_contents;
+
+/**
+ * DiffRangeDetectionTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Version\RangeDetection\DiffRangeDetection::class)]
+final class DiffRangeDetectionTest extends Framework\TestCase
+{
+    private Objects\Diff\Diff $diff;
+    private Src\Version\RangeDetection\DiffRangeDetection $subject;
+
+    public function setUp(): void
+    {
+        $this->diff = new Objects\Diff\Diff(new Repository(__DIR__));
+        $this->subject = new Src\Version\RangeDetection\DiffRangeDetection($this->diff);
+    }
+
+    #[Framework\Attributes\Test]
+    public function matchesReturnsFalseIfNoDiffObjectsAreStoredInDiff(): void
+    {
+        $pattern = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::FileAdded,
+            '/foo/',
+        );
+
+        self::assertFalse($this->subject->matches($pattern));
+    }
+
+    #[Framework\Attributes\Test]
+    public function matchesReturnsFalseIfNoDiffObjectMatchesGivenTypeOfPattern(): void
+    {
+        $pattern = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::FileAdded,
+            '/foo/',
+        );
+
+        $diff = (string) file_get_contents(dirname(__DIR__, 2).'/Fixtures/Git/diff-tag-deleted.txt');
+        $lines = array_map('rtrim', explode(PHP_EOL, $diff));
+
+        $this->diff[] = new Objects\Diff\DiffObject($lines);
+
+        self::assertFalse($this->subject->matches($pattern));
+    }
+
+    #[Framework\Attributes\Test]
+    public function matchesReturnsFalseIfNoDiffObjectMatchesGivenPattern(): void
+    {
+        $pattern = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::FileAdded,
+            '/foo/',
+        );
+
+        $diff = (string) file_get_contents(dirname(__DIR__, 2).'/Fixtures/Git/diff-tag-added.txt');
+        $lines = array_map('rtrim', explode(PHP_EOL, $diff));
+
+        $this->diff[] = new Objects\Diff\DiffObject($lines);
+
+        self::assertFalse($this->subject->matches($pattern));
+    }
+
+    #[Framework\Attributes\Test]
+    public function matchesReturnsTrueIfAnyDiffObjectMatchesGivenPattern(): void
+    {
+        $pattern = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::FileAdded,
+            '/^README\.md$/',
+        );
+
+        $diff = (string) file_get_contents(dirname(__DIR__, 2).'/Fixtures/Git/diff-tag-added.txt');
+        $lines = array_map('rtrim', explode(PHP_EOL, $diff));
+
+        $this->diff[] = new Objects\Diff\DiffObject($lines);
+
+        self::assertTrue($this->subject->matches($pattern));
+    }
+
+    #[Framework\Attributes\Test]
+    public function supportsReturnsFalseIfNoDiffObjectsAreStoredInDiff(): void
+    {
+        $pattern = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::FileAdded,
+            '/foo/',
+        );
+
+        self::assertFalse($this->subject->supports($pattern));
+    }
+
+    #[Framework\Attributes\Test]
+    public function supportsReturnsFalseIfNoDiffObjectMatchesGivenTypeOfPattern(): void
+    {
+        $pattern = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::FileAdded,
+            '/foo/',
+        );
+
+        $diff = (string) file_get_contents(dirname(__DIR__, 2).'/Fixtures/Git/diff-tag-deleted.txt');
+        $lines = array_map('rtrim', explode(PHP_EOL, $diff));
+
+        $this->diff[] = new Objects\Diff\DiffObject($lines);
+
+        self::assertFalse($this->subject->supports($pattern));
+    }
+
+    #[Framework\Attributes\Test]
+    public function supportsReturnsTrueIfAnyDiffObjectMatchesGivenTypeOfPattern(): void
+    {
+        $pattern = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::FileAdded,
+            '/foo/',
+        );
+
+        $diff = (string) file_get_contents(dirname(__DIR__, 2).'/Fixtures/Git/diff-tag-added.txt');
+        $lines = array_map('rtrim', explode(PHP_EOL, $diff));
+
+        $this->diff[] = new Objects\Diff\DiffObject($lines);
+
+        self::assertTrue($this->subject->supports($pattern));
+    }
+}

--- a/tests/src/Version/VersionRangeDetectorTest.php
+++ b/tests/src/Version/VersionRangeDetectorTest.php
@@ -1,0 +1,364 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Version;
+
+use EliasHaeussler\VersionBumper as Src;
+use EliasHaeussler\VersionBumper\Tests;
+use Exception;
+use Generator;
+use PHPUnit\Framework;
+
+/**
+ * VersionRangeDetectorTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Version\VersionRangeDetector::class)]
+final class VersionRangeDetectorTest extends Framework\TestCase
+{
+    private Tests\Fixtures\Classes\DummyCaller $caller;
+    private Src\Version\VersionRangeDetector $subject;
+
+    public function setUp(): void
+    {
+        $this->caller = new Tests\Fixtures\Classes\DummyCaller();
+        $this->subject = new Src\Version\VersionRangeDetector($this->caller);
+    }
+
+    #[Framework\Attributes\Test]
+    public function detectThrowsExceptionIfGivenVersionTagDoesNotExist(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\GitTagDoesNotExist('1.2.0'),
+        );
+
+        $this->subject->detect(__DIR__, [], '1.2.0');
+    }
+
+    #[Framework\Attributes\Test]
+    public function detectThrowsExceptionIfGivenVersionTagCannotBeRead(): void
+    {
+        $this->caller->results = [
+            [new Exception('something went wrong'), 'tag'],
+        ];
+
+        $this->expectExceptionObject(
+            new Src\Exception\CannotFetchGitTag('1.2.0'),
+        );
+
+        $this->subject->detect(__DIR__, [], '1.2.0');
+    }
+
+    #[Framework\Attributes\Test]
+    public function detectThrowsExceptionIfLatestVersionTagCannotBeRead(): void
+    {
+        $this->caller->results = [
+            [new Exception('something went wrong'), 'tag'],
+        ];
+
+        $this->expectExceptionObject(
+            new Src\Exception\CannotFetchLatestGitTag(),
+        );
+
+        $this->subject->detect(__DIR__, []);
+    }
+
+    #[Framework\Attributes\Test]
+    public function detectThrowsExceptionIfNoTagsAreAvailable(): void
+    {
+        $this->caller->results = [
+            ['', 'tag'],
+        ];
+
+        $this->expectExceptionObject(
+            new Src\Exception\NoGitTagsFound(),
+        );
+
+        $this->subject->detect(__DIR__, []);
+    }
+
+    #[Framework\Attributes\Test]
+    public function detectThrowsExceptionIfNoVersionTagsAreAvailable(): void
+    {
+        $this->caller->results = [
+            ['foo', 'tag'],
+            ['foo', 'tag'],
+            ['08708bc0b5c07a8233b6510c4677ad3ad112d5d4', "rev-list '-n1' 'refs/tags/foo'"],
+        ];
+
+        $this->expectExceptionObject(
+            new Src\Exception\NoGitTagsFound(),
+        );
+
+        $this->subject->detect(__DIR__, []);
+    }
+
+    #[Framework\Attributes\Test]
+    public function detectThrowsExceptionIfCommitMessagesCannotBeRead(): void
+    {
+        $this->caller->results = [
+            ['1.2.0', 'tag'],
+            ['1.2.0', 'tag'],
+            ['08708bc0b5c07a8233b6510c4677ad3ad112d5d4', "rev-list '-n1' 'refs/tags/1.2.0'"],
+            [new Exception('something went wrong'), "log '-s' '--pretty=raw' '--no-color' '--max-count=-1' '--skip=0' 'refs/tags/1.2.0..HEAD'"],
+        ];
+
+        $this->expectExceptionObject(
+            new Src\Exception\CannotFetchGitCommits('1.2.0..HEAD'),
+        );
+
+        $this->subject->detect(__DIR__, [], '1.2.0');
+    }
+
+    /**
+     * @param list<Src\Config\VersionRangeIndicator> $indicators
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('detectReturnsAutoDetectedVersionRangeForGivenVersionTagDataProvider')]
+    public function detectReturnsAutoDetectedVersionRangeForGivenVersionTag(
+        array $indicators,
+        ?Src\Enum\VersionRange $expected,
+    ): void {
+        $commit = (string) file_get_contents(dirname(__DIR__).'/Fixtures/Git/log-commit.txt');
+        $tag = (string) file_get_contents(dirname(__DIR__).'/Fixtures/Git/show-tag.txt');
+        $diff = (string) file_get_contents(dirname(__DIR__).'/Fixtures/Git/diff-tag-added.txt');
+
+        $this->caller->results = [
+            ['1.2.0', 'tag'],
+            ['1.2.0', 'tag'],
+            ['08708bc0b5c07a8233b6510c4677ad3ad112d5d4', "rev-list '-n1' 'refs/tags/1.2.0'"],
+            [$commit, "log '-s' '--pretty=raw' '--no-color' '--max-count=-1' '--skip=0' 'refs/tags/1.2.0..HEAD'"],
+            [$tag, "show '-s' '--pretty=raw' '--no-color' '1.2.0'"],
+            [$diff, "diff '--full-index' '--no-color' '--no-ext-diff' '-M' '--dst-prefix=DST/' '--src-prefix=SRC/' '08708bc0b5c07a8233b6510c4677ad3ad112d5d4^..08708bc0b5c07a8233b6510c4677ad3ad112d5d4'"],
+        ];
+
+        $actual = $this->subject->detect(__DIR__, $indicators, '1.2.0');
+
+        self::assertSame($expected, $actual);
+    }
+
+    #[Framework\Attributes\Test]
+    public function detectReturnsAutoDetectedVersionRangeForLatestVersionTag(): void
+    {
+        $indicators = [
+            new Src\Config\VersionRangeIndicator(
+                Src\Enum\VersionRange::Patch,
+                [
+                    new Src\Config\VersionRangePattern(
+                        Src\Enum\VersionRangeIndicatorType::FileAdded,
+                        '/^README\.md$/',
+                    ),
+                ],
+            ),
+        ];
+
+        $tags = <<<TAGS
+1.0.0
+1.0.1
+1.1.0
+1.2.0
+TAGS;
+
+        $commit = (string) file_get_contents(dirname(__DIR__).'/Fixtures/Git/log-commit.txt');
+        $tag = (string) file_get_contents(dirname(__DIR__).'/Fixtures/Git/show-tag.txt');
+        $diff = (string) file_get_contents(dirname(__DIR__).'/Fixtures/Git/diff-tag-added.txt');
+
+        $this->caller->results = [
+            [$tags, 'tag'],
+            [$tags, 'tag'],
+            ['08708bc0b5c07a8233b6510c4677ad3ad112d5d4', "rev-list '-n1' 'refs/tags/1.0.0'"],
+            [$tags, 'tag'],
+            ['08708bc0b5c07a8233b6510c4677ad3ad112d5d4', "rev-list '-n1' 'refs/tags/1.0.1'"],
+            [$tags, 'tag'],
+            ['08708bc0b5c07a8233b6510c4677ad3ad112d5d4', "rev-list '-n1' 'refs/tags/1.1.0'"],
+            [$tags, 'tag'],
+            ['08708bc0b5c07a8233b6510c4677ad3ad112d5d4', "rev-list '-n1' 'refs/tags/1.2.0'"],
+            [$commit, "log '-s' '--pretty=raw' '--no-color' '--max-count=-1' '--skip=0' 'refs/tags/1.2.0..HEAD'"],
+            [$tag, "show '-s' '--pretty=raw' '--no-color' '1.2.0'"],
+            [$diff, "diff '--full-index' '--no-color' '--no-ext-diff' '-M' '--dst-prefix=DST/' '--src-prefix=SRC/' '08708bc0b5c07a8233b6510c4677ad3ad112d5d4^..08708bc0b5c07a8233b6510c4677ad3ad112d5d4'"],
+        ];
+
+        $actual = $this->subject->detect(__DIR__, $indicators);
+
+        self::assertSame(Src\Enum\VersionRange::Patch, $actual);
+    }
+
+    /**
+     * @return Generator<string, array{list<Src\Config\VersionRangeIndicator>, Src\Enum\VersionRange|null}>
+     */
+    public static function detectReturnsAutoDetectedVersionRangeForGivenVersionTagDataProvider(): Generator
+    {
+        $matchedCommitMessage = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+            '/Hello World/',
+        );
+        $unmatchedCommitMessage = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+            '/foo/',
+        );
+
+        $matchedFileAdded = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::FileAdded,
+            '/^README\.md$/',
+        );
+        $unmatchedFileAdded = new Src\Config\VersionRangePattern(
+            Src\Enum\VersionRangeIndicatorType::FileAdded,
+            '/foo/',
+        );
+
+        yield 'no matches (without indicators)' => [[], null];
+        yield 'no matches (with matchAny strategy)' => [
+            [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Patch,
+                    [
+                        $unmatchedFileAdded,
+                        $unmatchedCommitMessage,
+                    ],
+                ),
+            ],
+            null,
+        ];
+        yield 'no matches (with matchAll strategy)' => [
+            [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Patch,
+                    [
+                        $matchedFileAdded,
+                        $unmatchedCommitMessage,
+                    ],
+                    Src\Enum\VersionRangeIndicatorStrategy::MatchAll,
+                ),
+            ],
+            null,
+        ];
+        yield 'no matches (with matchNone strategy)' => [
+            [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Patch,
+                    [
+                        $matchedFileAdded,
+                        $unmatchedCommitMessage,
+                    ],
+                    Src\Enum\VersionRangeIndicatorStrategy::MatchNone,
+                ),
+            ],
+            null,
+        ];
+
+        yield 'matches (with matchAny strategy)' => [
+            [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Patch,
+                    [
+                        $unmatchedFileAdded,
+                        $matchedCommitMessage,
+                    ],
+                ),
+            ],
+            Src\Enum\VersionRange::Patch,
+        ];
+        yield 'matches (with matchAll strategy)' => [
+            [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Patch,
+                    [
+                        $matchedCommitMessage,
+                        $matchedFileAdded,
+                    ],
+                    Src\Enum\VersionRangeIndicatorStrategy::MatchAll,
+                ),
+            ],
+            Src\Enum\VersionRange::Patch,
+        ];
+        yield 'matches (with matchNone strategy)' => [
+            [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Patch,
+                    [
+                        $unmatchedCommitMessage,
+                        $unmatchedFileAdded,
+                    ],
+                    Src\Enum\VersionRangeIndicatorStrategy::MatchNone,
+                ),
+            ],
+            Src\Enum\VersionRange::Patch,
+        ];
+
+        yield 'no matches (with multiple indicators)' => [
+            [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Patch,
+                    [
+                        $unmatchedCommitMessage,
+                        $unmatchedFileAdded,
+                    ],
+                    Src\Enum\VersionRangeIndicatorStrategy::MatchAll,
+                ),
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Minor,
+                    [
+                        $matchedFileAdded,
+                    ],
+                    Src\Enum\VersionRangeIndicatorStrategy::MatchNone,
+                ),
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Major,
+                    [
+                        $unmatchedCommitMessage,
+                    ],
+                ),
+            ],
+            null,
+        ];
+
+        yield 'matches (with multiple indicators)' => [
+            [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Patch,
+                    [
+                        $matchedCommitMessage,
+                        $matchedFileAdded,
+                    ],
+                    Src\Enum\VersionRangeIndicatorStrategy::MatchAll,
+                ),
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Minor,
+                    [
+                        $unmatchedFileAdded,
+                    ],
+                    Src\Enum\VersionRangeIndicatorStrategy::MatchNone,
+                ),
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Major,
+                    [
+                        $unmatchedCommitMessage,
+                    ],
+                ),
+            ],
+            Src\Enum\VersionRange::Minor,
+        ];
+    }
+}


### PR DESCRIPTION
This PR introduces a new library component: `VersionRangeDetector`. It is responsible for auto-detection of a version range to use when bumping versions in configured files. The version range detector comes into play as soon as the version or version range is omitted in the `composer bump-version` command. Hence, with this PR the command argument `version` is now optional.

Version range detection must be configured by so-called "version range indicators". At the moment, the following types of indicators are supported:

* Commit message
* Added file
* Deleted file
* Modified file

Each type must be associated with a pattern (regular expression) to match the respective Git information.

Example configuration:

```yaml
versionRangeIndicators:
  # Bump major version if controllers are deleted
  - range: major
    patterns:
      - type: fileDeleted
        pattern: '/^src\/Controller\/.+Controller$/'

  # Bump major version on breaking changes, determined by commit message
  - range: major
    patterns:
      - type: commitMessage
        pattern: '/^\[!!!]/'

  # Bump minor version when new features are added
  - range: minor
    patterns:
      - type: commitMessage
        pattern: '/^\[FEATURE]/'

  # Bump patch version if maintenance or documentation tasks were performed
  - range: patch
    patterns:
      - type: commitMessage
        pattern: '/^\[TASK]/'
      - type: commitMessage
        pattern: '/^\[BUGFIX]/'
      - type: commitMessage
        pattern: '/^\[DOCS]/'
```