### PR TITLE
[!!!][FEATURE] Introduce config presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,52 @@ Pass the following options to the console command:
   calculate and display version bumps.
 * `--strict`: Fail if any unmatched file pattern is reported.
 
+#### Presets
+
+Config presets can be used to ship preconfigured configuration
+for specific project types. When using presets in your config
+file, the resulting config will be merged with your main config
+object.
+
+Presets are identified by a name and can be customized by preset
+options. The available options differ between presets.
+
+##### Available presets
+
+* **Composer package**
+  - Identifier: `composer-package`
+  - Options:
+    + `path` (string, optional): Directory where `composer.json`
+      is located, defaults to current directory.
+* **NPM package**
+  - Identifier: `npm-package`
+  - Options:
+    + `packageName` (string, required): Name of the package as
+      configured in `package.json`.
+    + `path` (string, optional): Directory where `package.json`
+      is located, defaults to current directory.
+* **TYPO3 extension**
+  - Identifier: `typo3-extension`
+  - Options:
+    + `documentation` (boolean, optional): Define whether or not
+      a ReST documentation is used in the extension.
+
+##### Example
+
+```yaml
+presets:
+  # Short syntax, only identifier is provided
+  - composer-package
+
+  # Extended syntax, identifier and options are provided
+  - name: npm-package
+    options:
+      packageName: '@vendor/my-fancy-library'
+
+  # Extended syntax, but without options (not practically relevant, but possible)
+  - name: typo3-extension
+```
+
 #### Version range auto-detection
 
 Normally, an explicit version range or version is passed to
@@ -310,6 +356,12 @@ The following file formats are supported currently:
 The config file must follow a given schema:
 
 ```yaml
+presets:
+  - composer-package
+  - name: npm-package
+    options:
+      packageName: '@vendor/my-fancy-library'
+
 filesToModify:
   - path: relative/or/absolute/path/to/file
     patterns:
@@ -340,6 +392,18 @@ versionRangeIndicators:
 
 > [!TIP]
 > Have a look at the shipped [JSON schema](res/version-bumper.schema.json).
+
+#### Presets
+
+| Property            | Type                     | Required       | Description                                                                                                                  |
+|---------------------|--------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------|
+| `presets`           | Array of objects/strings | –              | List of config presets to apply (read more at [Presets](#presets)).                                                          |
+| `presets.*`         | String                   | ✅<sup>1)</sup> | Preset identifier, can be used when no additional options are to be configured. Otherwise, take a look at the next property. |
+| `presets.*.name`    | String                   | ✅<sup>1)</sup> | Preset identifier, can be used when additional options are to be configured (see next property).                             |
+| `presets.*.options` | Object                   | ✅<sup>1)</sup> | Additional preset options. The available options differ from preset to preset.                                               |
+
+<sup>1)</sup> You can either configure presets using string syntax (provide the
+preset identifier only) or using object syntax (provide identifier and options).
 
 #### Files to modify
 

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,11 @@
 	"require": {
 		"php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
 		"composer-plugin-api": "^2.0",
-		"cuyz/valinor": "^1.0",
+		"cuyz/valinor": "^1.12",
 		"cypresslab/gitelephant": "^4.5",
 		"symfony/console": "^5.4 || ^6.4 || ^7.0",
 		"symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
+		"symfony/options-resolver": "^5.4 || ^6.4 || ^7.0",
 		"symfony/yaml": "^5.4 || ^6.4 || ^7.0"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22b58fa56cdc09ed9692ba0d2145ec35",
+    "content-hash": "01ed5957b08bb93eefc5ed74cdb5b3e1",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -611,6 +611,73 @@
                 }
             ],
             "time": "2024-12-29T13:51:37+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v6.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "368128ad168f20e22c32159b9f761e456cec0c78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/368128ad168f20e22c32159b9f761e456cec0c78",
+                "reference": "368128ad168f20e22c32159b9f761e456cec0c78",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v6.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-20T10:57:02+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5992,73 +6059,6 @@
                 }
             ],
             "time": "2024-12-02T11:09:41+00:00"
-        },
-        {
-            "name": "symfony/options-resolver",
-            "version": "v6.4.16",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "368128ad168f20e22c32159b9f761e456cec0c78"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/368128ad168f20e22c32159b9f761e456cec0c78",
-                "reference": "368128ad168f20e22c32159b9f761e456cec0c78",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\OptionsResolver\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an improved replacement for the array_replace PHP function",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "config",
-                "configuration",
-                "options"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v6.4.16"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-11-20T10:57:02+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",

--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -3,6 +3,20 @@
 	"type": "object",
 	"title": "Version Bumper config file schema",
 	"properties": {
+		"presets": {
+			"type": "array",
+			"title": "List of presets to apply",
+			"items": {
+				"oneOf": [
+					{
+						"$ref": "#/definitions/preset"
+					},
+					{
+						"$ref": "#/definitions/presetShort"
+					}
+				]
+			}
+		},
 		"filesToModify": {
 			"type": "array",
 			"title": "List of files that contain versions which are to be bumped",
@@ -57,6 +71,105 @@
 			"required": [
 				"path",
 				"patterns"
+			]
+		},
+		"preset": {
+			"type": "object",
+			"title": "Default preset configuration",
+			"oneOf": [
+				{
+					"properties": {
+						"name": {
+							"type": "string",
+							"enum": [
+								"composer-package"
+							]
+						},
+						"options": {
+							"type": "object",
+							"properties": {
+								"path": {
+									"type": "string",
+									"title": "Path to composer.json",
+									"default": null
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"name",
+						"options"
+					]
+				},
+				{
+					"properties": {
+						"name": {
+							"type": "string",
+							"enum": [
+								"npm-package"
+							]
+						},
+						"options": {
+							"type": "object",
+							"properties": {
+								"packageName": {
+									"type": "string",
+									"title": "NPM package name as defined in package.json"
+								},
+								"path": {
+									"type": "string",
+									"title": "Path to package.json",
+									"default": null
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"packageName"
+							]
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"name",
+						"options"
+					]
+				},
+				{
+					"properties": {
+						"name": {
+							"type": "string",
+							"enum": [
+								"typo3-extension"
+							]
+						},
+						"options": {
+							"type": "object",
+							"properties": {
+								"documentation": {
+									"type": "boolean",
+									"title": "Define whether extension has a ReST documentation",
+									"default": false
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"name"
+					]
+				}
+			]
+		},
+		"presetShort": {
+			"type": "string",
+			"title": "Short preset configuration",
+			"description": "Configuration for presets which do not have required preset options",
+			"enum": [
+				"composer-package",
+				"typo3-extension"
 			]
 		},
 		"releaseOptions": {

--- a/src/Config/ConfigReader.php
+++ b/src/Config/ConfigReader.php
@@ -76,6 +76,10 @@ final class ConfigReader
             );
         }
 
+        foreach ($config->presets() as $preset) {
+            $config = $config->merge($preset->getConfig());
+        }
+
         return $config;
     }
 
@@ -116,7 +120,14 @@ final class ConfigReader
 
     private function createMapper(): Valinor\Mapper\TreeMapper
     {
+        $presetFactory = new Preset\PresetFactory();
+
         return (new Valinor\MapperBuilder())
+            ->registerConstructor(
+                $presetFactory->get(...),
+                static fn (string $name): Preset\Preset => $presetFactory->get($name),
+            )
+            ->allowPermissiveTypes()
             ->mapper()
         ;
     }

--- a/src/Config/Preset/BasePreset.php
+++ b/src/Config/Preset/BasePreset.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Config\Preset;
+
+use EliasHaeussler\VersionBumper\Exception;
+use Symfony\Component\OptionsResolver;
+
+/**
+ * BasePreset.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @template TOptions of array<string, mixed>
+ */
+abstract class BasePreset implements Preset
+{
+    /**
+     * @var TOptions
+     */
+    protected array $options;
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return TOptions
+     *
+     * @throws Exception\PresetOptionsAreInvalid
+     */
+    protected function resolveOptions(array $options): array
+    {
+        $optionsResolver = $this->createOptionsResolver();
+
+        try {
+            /* @phpstan-ignore return.type */
+            return $optionsResolver->resolve($options);
+        } catch (OptionsResolver\Exception\MissingOptionsException $exception) {
+            throw new Exception\PresetOptionsAreInvalid($this, $exception);
+        }
+    }
+
+    abstract protected function createOptionsResolver(): OptionsResolver\OptionsResolver;
+}

--- a/src/Config/Preset/ComposerPackagePreset.php
+++ b/src/Config/Preset/ComposerPackagePreset.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Config\Preset;
+
+use EliasHaeussler\VersionBumper\Config;
+use Symfony\Component\OptionsResolver;
+
+use function ltrim;
+
+/**
+ * ComposerPackagePreset.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @extends BasePreset<array{path: string|null}>
+ */
+final class ComposerPackagePreset extends BasePreset
+{
+    public function __construct(array $options = [])
+    {
+        $this->options = $this->resolveOptions($options);
+    }
+
+    public function getConfig(): Config\VersionBumperConfig
+    {
+        $filesToModify = [
+            new Config\FileToModify(
+                $this->resolvePath('composer.json'),
+                [
+                    new Config\FilePattern('"version": "{%version%}"'),
+                ],
+                true,
+            ),
+        ];
+
+        return new Config\VersionBumperConfig(filesToModify: $filesToModify);
+    }
+
+    public static function getIdentifier(): string
+    {
+        return 'composer-package';
+    }
+
+    public static function getDescription(): string
+    {
+        return 'Composer package, managed by composer.json';
+    }
+
+    private function resolvePath(string $filename): string
+    {
+        return ltrim($this->options['path'].'/'.$filename, '/');
+    }
+
+    protected function createOptionsResolver(): OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = new OptionsResolver\OptionsResolver();
+        $optionsResolver->define('path')
+            ->allowedTypes('string')
+            ->default('')
+        ;
+
+        return $optionsResolver;
+    }
+}

--- a/src/Config/Preset/NpmPackagePreset.php
+++ b/src/Config/Preset/NpmPackagePreset.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Config\Preset;
+
+use EliasHaeussler\VersionBumper\Config;
+use Symfony\Component\OptionsResolver;
+
+use function ltrim;
+use function sprintf;
+
+/**
+ * NpmPackagePreset.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @extends BasePreset<array{packageName: string, path: string|null}>
+ */
+final class NpmPackagePreset extends BasePreset
+{
+    public function __construct(array $options)
+    {
+        $this->options = $this->resolveOptions($options);
+    }
+
+    public function getConfig(): Config\VersionBumperConfig
+    {
+        $filesToModify = [
+            new Config\FileToModify(
+                $this->resolvePath('package.json'),
+                [
+                    new Config\FilePattern('"version": "{%version%}"'),
+                ],
+                true,
+            ),
+            new Config\FileToModify(
+                $this->resolvePath('package-lock.json'),
+                [
+                    new Config\FilePattern(
+                        sprintf(
+                            '"name": "%s",\s+"version": "{%%version%%}"',
+                            $this->options['packageName'],
+                        ),
+                    ),
+                ],
+                true,
+            ),
+        ];
+
+        return new Config\VersionBumperConfig(filesToModify: $filesToModify);
+    }
+
+    public static function getIdentifier(): string
+    {
+        return 'npm-package';
+    }
+
+    public static function getDescription(): string
+    {
+        return 'NPM package, managed by package.json and package-lock.json';
+    }
+
+    private function resolvePath(string $filename): string
+    {
+        return ltrim($this->options['path'].'/'.$filename, '/');
+    }
+
+    protected function createOptionsResolver(): OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = new OptionsResolver\OptionsResolver();
+        $optionsResolver->define('packageName')
+            ->allowedTypes('string')
+            ->required()
+        ;
+        $optionsResolver->define('path')
+            ->allowedTypes('string')
+            ->default('')
+        ;
+
+        return $optionsResolver;
+    }
+}

--- a/src/Config/Preset/Preset.php
+++ b/src/Config/Preset/Preset.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Config\Preset;
+
+use EliasHaeussler\VersionBumper\Config;
+use EliasHaeussler\VersionBumper\Exception;
+
+/**
+ * Preset.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+interface Preset
+{
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @throws Exception\PresetOptionsAreInvalid
+     */
+    public function __construct(array $options);
+
+    public function getConfig(): Config\VersionBumperConfig;
+
+    public static function getIdentifier(): string;
+
+    public static function getDescription(): string;
+}

--- a/src/Config/Preset/PresetFactory.php
+++ b/src/Config/Preset/PresetFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Config\Preset;
+
+use EliasHaeussler\VersionBumper\Exception;
+
+/**
+ * PresetFactory.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class PresetFactory
+{
+    private const PRESETS = [
+        ComposerPackagePreset::class,
+        NpmPackagePreset::class,
+        Typo3ExtensionPreset::class,
+    ];
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @throws Exception\PresetDoesNotExist
+     */
+    public function get(string $name, array $options = []): Preset
+    {
+        /** @var class-string<Preset> $presetClass */
+        foreach (self::PRESETS as $presetClass) {
+            if ($presetClass::getIdentifier() === $name) {
+                return new $presetClass($options);
+            }
+        }
+
+        throw new Exception\PresetDoesNotExist($name);
+    }
+}

--- a/src/Config/Preset/Typo3ExtensionPreset.php
+++ b/src/Config/Preset/Typo3ExtensionPreset.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Config\Preset;
+
+use EliasHaeussler\VersionBumper\Config;
+use Symfony\Component\OptionsResolver;
+
+/**
+ * Typo3ExtensionPreset.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @extends BasePreset<array{documentation: bool}>
+ */
+final class Typo3ExtensionPreset extends BasePreset
+{
+    public function __construct(array $options = [])
+    {
+        $this->options = $this->resolveOptions($options);
+    }
+
+    public function getConfig(): Config\VersionBumperConfig
+    {
+        $filesToModify = [
+            new Config\FileToModify(
+                'ext_emconf.php',
+                [
+                    new Config\FilePattern("'version' => '{%version%}'"),
+                ],
+                true,
+            ),
+        ];
+
+        if ($this->options['documentation']) {
+            $filesToModify[] = new Config\FileToModify(
+                'Documentation/guides.xml',
+                [
+                    new Config\FilePattern('release="{%version%}"'),
+                ],
+                true,
+            );
+        }
+
+        return new Config\VersionBumperConfig(filesToModify: $filesToModify);
+    }
+
+    public static function getIdentifier(): string
+    {
+        return 'typo3-extension';
+    }
+
+    public static function getDescription(): string
+    {
+        return 'TYPO3 extension, managed by ext_emconf.php';
+    }
+
+    protected function createOptionsResolver(): OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = new OptionsResolver\OptionsResolver();
+        $optionsResolver->define('documentation')
+            ->allowedTypes('bool')
+            ->default(false)
+        ;
+
+        return $optionsResolver;
+    }
+}

--- a/src/Exception/PresetDoesNotExist.php
+++ b/src/Exception/PresetDoesNotExist.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Exception;
+
+use function sprintf;
+
+/**
+ * PresetDoesNotExist.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class PresetDoesNotExist extends Exception
+{
+    public function __construct(string $name)
+    {
+        parent::__construct(
+            sprintf('Preset "%s" does not exist.', $name),
+            1736639626,
+        );
+    }
+}

--- a/src/Exception/PresetOptionsAreInvalid.php
+++ b/src/Exception/PresetOptionsAreInvalid.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Exception;
+
+use EliasHaeussler\VersionBumper\Config;
+use Throwable;
+
+use function sprintf;
+
+/**
+ * PresetOptionsAreInvalid.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class PresetOptionsAreInvalid extends Exception
+{
+    public function __construct(Config\Preset\Preset $preset, Throwable $previous)
+    {
+        parent::__construct(
+            sprintf('Options of preset "%s" are invalid: %s', $preset::getIdentifier(), $previous->getMessage()),
+            1736677999,
+            $previous,
+        );
+    }
+}

--- a/tests/src/Command/BumpVersionCommandTest.php
+++ b/tests/src/Command/BumpVersionCommandTest.php
@@ -252,6 +252,28 @@ final class BumpVersionCommandTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function executeDecoratesAppliedPresets(): void
+    {
+        $configFile = dirname(__DIR__).'/Fixtures/ConfigFiles/valid-config-with-typo3-extension-preset.json';
+
+        $this->commandTester->execute(
+            [
+                'range' => '2.0.0',
+                '--config' => $configFile,
+                '--dry-run' => true,
+            ],
+            [
+                'verbosity' => Console\Output\OutputInterface::VERBOSITY_VERBOSE,
+            ],
+        );
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('Applied presets', $output);
+        self::assertStringContainsString('* TYPO3 extension, managed by ext_emconf.php (typo3-extension)', $output);
+    }
+
+    #[Framework\Attributes\Test]
     public function executeDecoratesVersionBumpResult(): void
     {
         $configFile = dirname(__DIR__).'/Fixtures/ConfigFiles/valid-config-with-root-path.json';

--- a/tests/src/Config/Preset/BasePresetTest.php
+++ b/tests/src/Config/Preset/BasePresetTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Config\Preset;
+
+use EliasHaeussler\VersionBumper as Src;
+use EliasHaeussler\VersionBumper\Tests;
+use PHPUnit\Framework;
+
+/**
+ * BasePresetTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Config\Preset\BasePreset::class)]
+final class BasePresetTest extends Framework\TestCase
+{
+    private Tests\Fixtures\Classes\DummyPreset $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Tests\Fixtures\Classes\DummyPreset();
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveOptionsThrowsExceptionIfRequiredOptionsAreMissing(): void
+    {
+        $this->expectException(Src\Exception\PresetOptionsAreInvalid::class);
+
+        $this->subject->resolveOptions([]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveOptionsResolvesGivenOptionsWithOptionsResolver(): void
+    {
+        $expected = [
+            'baz' => 'baz',
+            'foo' => 'foo',
+        ];
+
+        self::assertSame($expected, $this->subject->resolveOptions(['foo' => 'foo']));
+    }
+}

--- a/tests/src/Config/Preset/ComposerPackagePresetTest.php
+++ b/tests/src/Config/Preset/ComposerPackagePresetTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Config\Preset;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
+
+/**
+ * ComposerPackagePresetTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Config\Preset\ComposerPackagePreset::class)]
+final class ComposerPackagePresetTest extends Framework\TestCase
+{
+    private Src\Config\Preset\ComposerPackagePreset $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Config\Preset\ComposerPackagePreset([
+            'path' => 'foo/baz',
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function getConfigReturnsResolvedConfig(): void
+    {
+        $expected = new Src\Config\VersionBumperConfig(
+            filesToModify: [
+                new Src\Config\FileToModify(
+                    'foo/baz/composer.json',
+                    [
+                        new Src\Config\FilePattern('"version": "{%version%}"'),
+                    ],
+                    true,
+                ),
+            ],
+        );
+
+        self::assertEquals($expected, $this->subject->getConfig());
+    }
+}

--- a/tests/src/Config/Preset/NpmPackagePresetTest.php
+++ b/tests/src/Config/Preset/NpmPackagePresetTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Config\Preset;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
+
+/**
+ * NpmPackagePresetTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Config\Preset\NpmPackagePreset::class)]
+final class NpmPackagePresetTest extends Framework\TestCase
+{
+    private Src\Config\Preset\NpmPackagePreset $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Config\Preset\NpmPackagePreset([
+            'packageName' => '@foo/baz',
+            'path' => 'foo/baz',
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function constructorThrowsExceptionIfRequiredOptionIsMissing(): void
+    {
+        $this->expectException(Src\Exception\PresetOptionsAreInvalid::class);
+
+        new Src\Config\Preset\NpmPackagePreset([]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function getConfigReturnsResolvedConfig(): void
+    {
+        $expected = new Src\Config\VersionBumperConfig(
+            filesToModify: [
+                new Src\Config\FileToModify(
+                    'foo/baz/package.json',
+                    [
+                        new Src\Config\FilePattern('"version": "{%version%}"'),
+                    ],
+                    true,
+                ),
+                new Src\Config\FileToModify(
+                    'foo/baz/package-lock.json',
+                    [
+                        new Src\Config\FilePattern(
+                            '"name": "@foo/baz",\s+"version": "{%version%}"',
+                        ),
+                    ],
+                    true,
+                ),
+            ],
+        );
+
+        self::assertEquals($expected, $this->subject->getConfig());
+    }
+}

--- a/tests/src/Config/Preset/PresetFactoryTest.php
+++ b/tests/src/Config/Preset/PresetFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Config\Preset;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
+
+/**
+ * PresetFactoryTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Config\Preset\PresetFactory::class)]
+final class PresetFactoryTest extends Framework\TestCase
+{
+    private Src\Config\Preset\PresetFactory $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Config\Preset\PresetFactory();
+    }
+
+    #[Framework\Attributes\Test]
+    public function getThrowsExceptionIfGivenPresetDoesNotExist(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\PresetDoesNotExist('foo'),
+        );
+
+        $this->subject->get('foo');
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReturnsGivenPreset(): void
+    {
+        $expected = new Src\Config\Preset\Typo3ExtensionPreset();
+
+        self::assertEquals($expected, $this->subject->get('typo3-extension'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function getAppliesGivenConfigToPreset(): void
+    {
+        $expected = new Src\Config\Preset\NpmPackagePreset(['packageName' => '@foo/baz']);
+
+        self::assertEquals($expected, $this->subject->get('npm-package', ['packageName' => '@foo/baz']));
+    }
+}

--- a/tests/src/Config/Preset/Typo3ExtensionPresetTest.php
+++ b/tests/src/Config/Preset/Typo3ExtensionPresetTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Config\Preset;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
+
+/**
+ * Typo3ExtensionPresetTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Config\Preset\Typo3ExtensionPreset::class)]
+final class Typo3ExtensionPresetTest extends Framework\TestCase
+{
+    private Src\Config\Preset\Typo3ExtensionPreset $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Config\Preset\Typo3ExtensionPreset(['documentation' => true]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function getConfigReturnsResolvedConfig(): void
+    {
+        $expected = new Src\Config\VersionBumperConfig(
+            filesToModify: [
+                new Src\Config\FileToModify(
+                    'ext_emconf.php',
+                    [
+                        new Src\Config\FilePattern("'version' => '{%version%}'"),
+                    ],
+                    true,
+                ),
+                new Src\Config\FileToModify(
+                    'Documentation/guides.xml',
+                    [
+                        new Src\Config\FilePattern('release="{%version%}"'),
+                    ],
+                    true,
+                ),
+            ],
+        );
+
+        self::assertEquals($expected, $this->subject->getConfig());
+    }
+}

--- a/tests/src/Config/VersionBumperConfigTest.php
+++ b/tests/src/Config/VersionBumperConfigTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Config;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
+
+/**
+ * VersionBumperConfigTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Config\VersionBumperConfig::class)]
+final class VersionBumperConfigTest extends Framework\TestCase
+{
+    private Src\Config\VersionBumperConfig $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Config\VersionBumperConfig(
+            [
+                new Src\Config\Preset\Typo3ExtensionPreset(),
+            ],
+            [
+                new Src\Config\FileToModify(
+                    'foo',
+                    [
+                        'baz: {%version%}',
+                    ],
+                ),
+            ],
+            '/foo',
+            new Src\Config\ReleaseOptions(signTag: false),
+            [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Minor,
+                    [
+                        new Src\Config\VersionRangePattern(
+                            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+                            '/^\[FEATURE]/',
+                        ),
+                    ],
+                ),
+            ],
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function mergeSkipsDefaultValuesFromOtherConfig(): void
+    {
+        $other = new Src\Config\VersionBumperConfig(releaseOptions: new Src\Config\ReleaseOptions());
+
+        self::assertEquals($this->subject, $this->subject->merge($other));
+    }
+
+    #[Framework\Attributes\Test]
+    public function mergeMergesArrayPropertiesFromCurrentConfigWithArrayPropertiesFromOtherConfig(): void
+    {
+        $other = new Src\Config\VersionBumperConfig(
+            [
+                new Src\Config\Preset\NpmPackagePreset(['packageName' => '@foo/baz']),
+            ],
+        );
+
+        $expected = new Src\Config\VersionBumperConfig(
+            [
+                new Src\Config\Preset\Typo3ExtensionPreset(),
+                new Src\Config\Preset\NpmPackagePreset(['packageName' => '@foo/baz']),
+            ],
+            [
+                new Src\Config\FileToModify(
+                    'foo',
+                    [
+                        'baz: {%version%}',
+                    ],
+                ),
+            ],
+            '/foo',
+            new Src\Config\ReleaseOptions(signTag: false),
+            [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Minor,
+                    [
+                        new Src\Config\VersionRangePattern(
+                            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+                            '/^\[FEATURE]/',
+                        ),
+                    ],
+                ),
+            ],
+        );
+
+        self::assertEquals($expected, $this->subject->merge($other));
+    }
+
+    #[Framework\Attributes\Test]
+    public function mergeUsesNonDefaultAndNonArrayPropertyFromOtherConfig(): void
+    {
+        $other = new Src\Config\VersionBumperConfig(
+            rootPath: '/baz',
+        );
+
+        $expected = new Src\Config\VersionBumperConfig(
+            [
+                new Src\Config\Preset\Typo3ExtensionPreset(),
+            ],
+            [
+                new Src\Config\FileToModify(
+                    'foo',
+                    [
+                        'baz: {%version%}',
+                    ],
+                ),
+            ],
+            '/baz',
+            new Src\Config\ReleaseOptions(signTag: false),
+            [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Minor,
+                    [
+                        new Src\Config\VersionRangePattern(
+                            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+                            '/^\[FEATURE]/',
+                        ),
+                    ],
+                ),
+            ],
+        );
+
+        self::assertEquals($expected, $this->subject->merge($other));
+    }
+}

--- a/tests/src/Exception/PresetDoesNotExistTest.php
+++ b/tests/src/Exception/PresetDoesNotExistTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Exception;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
+
+/**
+ * PresetDoesNotExistTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Exception\PresetDoesNotExist::class)]
+final class PresetDoesNotExistTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function constructorCreatesExceptionForNonExistingFile(): void
+    {
+        $actual = new Src\Exception\PresetDoesNotExist('foo');
+
+        self::assertSame('Preset "foo" does not exist.', $actual->getMessage());
+        self::assertSame(1736639626, $actual->getCode());
+    }
+}

--- a/tests/src/Exception/PresetOptionsAreInvalidTest.php
+++ b/tests/src/Exception/PresetOptionsAreInvalidTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Exception;
+
+use EliasHaeussler\VersionBumper as Src;
+use Exception;
+use PHPUnit\Framework;
+
+/**
+ * PresetOptionsAreInvalidTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Exception\PresetOptionsAreInvalid::class)]
+final class PresetOptionsAreInvalidTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function constructorCreatesExceptionForGivenPresetAndException(): void
+    {
+        $previous = new Exception('foo baz is missing');
+        $actual = new Src\Exception\PresetOptionsAreInvalid(new Src\Config\Preset\Typo3ExtensionPreset(), $previous);
+
+        self::assertSame(
+            'Options of preset "typo3-extension" are invalid: foo baz is missing',
+            $actual->getMessage(),
+        );
+        self::assertSame(1736677999, $actual->getCode());
+        self::assertSame($previous, $actual->getPrevious());
+    }
+}

--- a/tests/src/Fixtures/Classes/DummyPreset.php
+++ b/tests/src/Fixtures/Classes/DummyPreset.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Fixtures\Classes;
+
+use EliasHaeussler\VersionBumper\Config;
+use EliasHaeussler\VersionBumper\Config\Preset\BasePreset;
+use Symfony\Component\OptionsResolver;
+
+/**
+ * DummyPreset.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ *
+ * @extends BasePreset<array<string, mixed>>
+ */
+final class DummyPreset extends BasePreset
+{
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
+    public function getConfig(): Config\VersionBumperConfig
+    {
+        return new Config\VersionBumperConfig();
+    }
+
+    public static function getIdentifier(): string
+    {
+        return 'dummy';
+    }
+
+    public static function getDescription(): string
+    {
+        return 'Dummy preset';
+    }
+
+    public function resolveOptions(array $options): array
+    {
+        return parent::resolveOptions($options);
+    }
+
+    protected function createOptionsResolver(): OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = new OptionsResolver\OptionsResolver();
+        $optionsResolver->define('foo')
+            ->allowedTypes('string')
+            ->required();
+        $optionsResolver->define('baz')
+            ->allowedTypes('string')
+            ->default('baz');
+
+        return $optionsResolver;
+    }
+}

--- a/tests/src/Fixtures/ConfigFiles/valid-config-with-composer-package-preset.json
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-with-composer-package-preset.json
@@ -1,0 +1,19 @@
+{
+	"presets": [
+		{
+			"name": "composer-package",
+			"options": {
+				"path": "foo"
+			}
+		}
+	],
+	"filesToModify": [
+		{
+			"path": "baz",
+			"patterns": [
+				"foo: {%version%}"
+			]
+		}
+	],
+	"rootPath": "../RootPath"
+}

--- a/tests/src/Fixtures/ConfigFiles/valid-config-with-composer-package-short-preset.json
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-with-composer-package-short-preset.json
@@ -1,0 +1,14 @@
+{
+	"presets": [
+		"composer-package"
+	],
+	"filesToModify": [
+		{
+			"path": "baz",
+			"patterns": [
+				"foo: {%version%}"
+			]
+		}
+	],
+	"rootPath": "../RootPath"
+}

--- a/tests/src/Fixtures/ConfigFiles/valid-config-with-npm-package-preset.json
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-with-npm-package-preset.json
@@ -1,0 +1,20 @@
+{
+	"presets": [
+		{
+			"name": "npm-package",
+			"options": {
+				"packageName": "@foo/baz",
+				"path": "foo"
+			}
+		}
+	],
+	"filesToModify": [
+		{
+			"path": "baz",
+			"patterns": [
+				"foo: {%version%}"
+			]
+		}
+	],
+	"rootPath": "../RootPath"
+}

--- a/tests/src/Fixtures/ConfigFiles/valid-config-with-typo3-extension-preset.json
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-with-typo3-extension-preset.json
@@ -1,0 +1,19 @@
+{
+	"presets": [
+		{
+			"name": "typo3-extension",
+			"options": {
+				"documentation": true
+			}
+		}
+	],
+	"filesToModify": [
+		{
+			"path": "baz",
+			"patterns": [
+				"foo: {%version%}"
+			]
+		}
+	],
+	"rootPath": "../RootPath"
+}

--- a/tests/src/Fixtures/ConfigFiles/valid-config-with-typo3-extension-short-preset.json
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-with-typo3-extension-short-preset.json
@@ -1,0 +1,14 @@
+{
+	"presets": [
+		"typo3-extension"
+	],
+	"filesToModify": [
+		{
+			"path": "baz",
+			"patterns": [
+				"foo: {%version%}"
+			]
+		}
+	],
+	"rootPath": "../RootPath"
+}


### PR DESCRIPTION
This PR introduces config presets. They can be used to provide basic configuration for a specific project type. At the moment, Composer packages, NPM packages and TYPO3 extensions are supported. Presets are configurable and their resulting version bumper config will be merged with the main config object.

Example usage:

```yaml
# version-bumper.yaml

presets:
  # Short syntax, provide only identifier without options
  - composer-package
  - 
  # Extended syntax, provide identifier and options
  - name: npm-package
    options:
      packageName: '@vendor/my-fancy-package'

  # Extended syntax, but provide only identifier (only for demonstration, not useful)
  - name: typo3-extension

# ...
```

This will result in the following config (simplified):

```yaml
filesToModify:
  # From composer-package preset
  - path: composer.json
    patterns:
      - '"version": "{%version%}"'
    reportUnmatched: true

  # From npm-package preset
  - path: package.json
    patterns:
      - '"version": "{%version%}"'
    reportUnmatched: true
  - path: package-lock.json
    patterns:
      - '"name": "@vendor/my-fancy-package",\s+"version": "{%version%}"'
    reportUnmatched: true

  # From typo3-extension preset
  - path: ext_emconf.php
    patterns:
      - "'version' => '{%version%}'"
    reportUnmatched: true
```