### PR TITLE
[FEATURE] Allow absence of files to modify via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ preset identifier only) or using object syntax (provide identifier and options).
 | `filesToModify.*.path`            | String           | ✅        | Relative or absolute path to the file. Relative paths are calculated from the configured (or calculated) project root.                                                                                                                                                            |
 | `filesToModify.*.patterns`        | Array of strings | ✅        | List of version patterns to be searched and replaced in the configured file. Each pattern must contain a `{%version%}` placeholder that is replaced by the new version. Patterns are internally converted to regular expressions, so feel free to use regex syntax such as `\s+`. |
 | `filesToModify.*.reportUnmatched` | Boolean          | –        | Show warning if a configured pattern does not match file contents. Useful in combination with the `--strict` command option.                                                                                                                                                      |
+| `filesToModify.*.reportMissing`   | Boolean          | –        | Fail if file to modify does not exist (defaults to `true`).                                                                                                                                                                                                                       |
 
 #### Release options
 

--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -64,7 +64,13 @@
 				},
 				"reportUnmatched": {
 					"type": "boolean",
-					"title": "Show warning if a configured pattern does not match file contents"
+					"title": "Show warning if a configured pattern does not match file contents",
+					"default": false
+				},
+				"reportMissing": {
+					"type": "boolean",
+					"title": "Fail if file to modify does not exist",
+					"default": true
 				}
 			},
 			"additionalProperties": false,

--- a/src/Config/FileToModify.php
+++ b/src/Config/FileToModify.php
@@ -50,6 +50,7 @@ final class FileToModify
         private readonly string $path,
         array $patterns = [],
         private readonly bool $reportUnmatched = false,
+        private readonly bool $reportMissing = true,
     ) {
         foreach ($patterns as $pattern) {
             $this->add($pattern);
@@ -95,5 +96,10 @@ final class FileToModify
     public function reportUnmatched(): bool
     {
         return $this->reportUnmatched;
+    }
+
+    public function reportMissing(): bool
+    {
+        return $this->reportMissing;
     }
 }

--- a/src/Version/VersionBumper.php
+++ b/src/Version/VersionBumper.php
@@ -28,8 +28,8 @@ use EliasHaeussler\VersionBumper\Enum;
 use EliasHaeussler\VersionBumper\Exception;
 use EliasHaeussler\VersionBumper\Result;
 
-use function file_exists;
 use function file_put_contents;
+use function is_file;
 use function preg_match_all;
 use function strlen;
 use function substr_replace;
@@ -87,7 +87,12 @@ final class VersionBumper
     ): Result\VersionBumpResult {
         $path = $file->fullPath($rootPath);
 
-        if (!file_exists($path)) {
+        if (!is_file($path)) {
+            // Early return if missing file should not be reported
+            if (!$file->reportMissing()) {
+                return new Result\VersionBumpResult($file, []);
+            }
+
             throw new Exception\FileDoesNotExist($path);
         }
 

--- a/tests/src/Version/VersionBumperTest.php
+++ b/tests/src/Version/VersionBumperTest.php
@@ -78,6 +78,26 @@ final class VersionBumperTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function bumpReturnsEmptyResultIfFileToModifyDoesNotExistAndReportMissingIsDisabled(): void
+    {
+        $fileToModify = new Src\Config\FileToModify(
+            'foo',
+            [
+                'foo: {%version%}',
+                'baz: {%version%}',
+            ],
+            reportMissing: false,
+        );
+
+        self::assertEquals(
+            [
+                new Src\Result\VersionBumpResult($fileToModify, []),
+            ],
+            $this->subject->bump([$fileToModify], '/baz', Src\Enum\VersionRange::Next),
+        );
+    }
+
+    #[Framework\Attributes\Test]
     public function bumpDoesNothingIfFileContentsWereNotModified(): void
     {
         $fooFile = $this->filesToModify[0];


### PR DESCRIPTION
This PR introduces a new config option `reportMissing` for files to modify. When set to `true` (default), the behavior is the same like before: configured files to modify need to exist, otherwise version bumping fails. If set to `false`, the absence of a configured file to modify is accepted and no longer throws an exception.