### PR TITLE
[!!!][TASK] Use strict semver for unstable versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,24 @@ composer require --dev eliashaeussler/version-bumper
 $ composer bump-version [<range>] [-c|--config CONFIG] [-r|--release] [--dry-run] [--strict]
 ```
 
+> [!IMPORTANT]
+> Unstable versions (< `1.0.0`) are handled differently.
+> Bumping major version increases the second version
+> number (`0.1.2` → `0.2.0`) and bumping minor version
+> increases the third version number (`0.1.2` → `0.1.3`).
+
 Pass the following options to the console command:
 
 * `<range>`: Version range to be bumped, can be one of:
   - `major`/`maj`: Bump version to next major version
-    (`1.2.3` -> `2.0.0`)
+    + stable: `1.2.3` → `2.0.0`
+    + unstable: `0.1.2` → `0.2.0`
   - `minor`/`min`: Bump version to next minor version
-    (`1.2.3` -> `1.3.0`)
-  - `next`/`n`/`patch`/`p`: Bump version to next patch
-    version (`1.2.3` -> `1.2.4`)
+    + stable: `1.2.3` → `1.3.0`
+    + unstable: `0.1.2` → `0.1.3`
+  - `next`/`n`/`patch`/`p`: Bump version to next patch version
+    + stable: `1.2.3` → `1.2.4`
+    + unstable: `0.1.2` → `0.1.3`
   - Explicit version, e.g. `1.3.0`
 * `-c`/`--config`: Path to [config file](#-configuration),
   defaults to auto-detection in current working directory,

--- a/tests/src/Version/VersionTest.php
+++ b/tests/src/Version/VersionTest.php
@@ -60,10 +60,19 @@ final class VersionTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    #[Framework\Attributes\DataProvider('increaseReturnsIncreasedVersionDataProvider')]
-    public function increaseReturnsIncreasedVersion(Src\Enum\VersionRange $range, Src\Version\Version $expected): void
+    #[Framework\Attributes\DataProvider('increaseReturnsIncreasedStableVersionDataProvider')]
+    public function increaseReturnsIncreasedStableVersion(Src\Enum\VersionRange $range, Src\Version\Version $expected): void
     {
         self::assertEquals($expected, $this->subject->increase($range));
+    }
+
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('increaseReturnsIncreasedUnstableVersionDataProvider')]
+    public function increaseReturnsIncreasedUnstableVersion(Src\Enum\VersionRange $range, Src\Version\Version $expected): void
+    {
+        $subject = new Src\Version\Version(0, 1, 2);
+
+        self::assertEquals($expected, $subject->increase($range));
     }
 
     #[Framework\Attributes\Test]
@@ -81,11 +90,22 @@ final class VersionTest extends Framework\TestCase
     /**
      * @return Generator<string, array{Src\Enum\VersionRange, Src\Version\Version}>
      */
-    public static function increaseReturnsIncreasedVersionDataProvider(): Generator
+    public static function increaseReturnsIncreasedStableVersionDataProvider(): Generator
     {
         yield 'major' => [Src\Enum\VersionRange::Major, new Src\Version\Version(2, 0, 0)];
         yield 'minor' => [Src\Enum\VersionRange::Minor, new Src\Version\Version(1, 3, 0)];
         yield 'next' => [Src\Enum\VersionRange::Next, new Src\Version\Version(1, 2, 4)];
         yield 'patch' => [Src\Enum\VersionRange::Patch, new Src\Version\Version(1, 2, 4)];
+    }
+
+    /**
+     * @return Generator<string, array{Src\Enum\VersionRange, Src\Version\Version}>
+     */
+    public static function increaseReturnsIncreasedUnstableVersionDataProvider(): Generator
+    {
+        yield 'major' => [Src\Enum\VersionRange::Major, new Src\Version\Version(0, 2, 0)];
+        yield 'minor' => [Src\Enum\VersionRange::Minor, new Src\Version\Version(0, 1, 3)];
+        yield 'next' => [Src\Enum\VersionRange::Next, new Src\Version\Version(0, 1, 3)];
+        yield 'patch' => [Src\Enum\VersionRange::Patch, new Src\Version\Version(0, 1, 3)];
     }
 }


### PR DESCRIPTION
This PR hardens version range handling by implementing strict semver for unstable versions (< `1.0.0`). Example:

* Major (stable): `1.2.3` → `2.0.0`
* Minor (stable): `1.2.3` → `1.3.0`
* Patch (stable): `1.2.3` → `1.2.4`
* Major (unstable): `0.1.2` → `0.2.0`
* Minor/Patch (unstable): `0.1.2` → `0.1.3`