### PR TITLE
[FEATURE] Automatically modify TYPO3 documentation version by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,11 @@ options. The available options differ between presets.
 * **TYPO3 extension**
   - Identifier: `typo3-extension`
   - Options:
-    + `documentation` (boolean, optional): Define whether or not
-      a ReST documentation is used in the extension.
+    + `documentation` (boolean or `auto` keyword, optional): Define
+      whether or not a ReST documentation is used in the extension.
+      By default or if keyword `auto` is used, ReST documentation
+      version may be replaced, if existent, but version bumping will
+      not fail if a ReST documentation does not exist.
 
 ##### Example
 

--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -154,9 +154,19 @@
 							"type": "object",
 							"properties": {
 								"documentation": {
-									"type": "boolean",
+									"oneOf": [
+										{
+											"type": "boolean"
+										},
+										{
+											"type": "string",
+											"enum": [
+												"auto"
+											]
+										}
+									],
 									"title": "Define whether extension has a ReST documentation",
-									"default": false
+									"default": "auto"
 								}
 							},
 							"additionalProperties": false

--- a/src/Config/Preset/Typo3ExtensionPreset.php
+++ b/src/Config/Preset/Typo3ExtensionPreset.php
@@ -32,10 +32,12 @@ use Symfony\Component\OptionsResolver;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  *
- * @extends BasePreset<array{documentation: bool}>
+ * @extends BasePreset<array{documentation: 'auto'|bool}>
  */
 final class Typo3ExtensionPreset extends BasePreset
 {
+    private const AUTO_KEYWORD = 'auto';
+
     public function __construct(array $options = [])
     {
         $this->options = $this->resolveOptions($options);
@@ -53,13 +55,14 @@ final class Typo3ExtensionPreset extends BasePreset
             ),
         ];
 
-        if ($this->options['documentation']) {
+        if (false !== $this->options['documentation']) {
             $filesToModify[] = new Config\FileToModify(
                 'Documentation/guides.xml',
                 [
                     new Config\FilePattern('release="{%version%}"'),
                 ],
                 true,
+                self::AUTO_KEYWORD !== $this->options['documentation'],
             );
         }
 
@@ -80,8 +83,8 @@ final class Typo3ExtensionPreset extends BasePreset
     {
         $optionsResolver = new OptionsResolver\OptionsResolver();
         $optionsResolver->define('documentation')
-            ->allowedTypes('bool')
-            ->default(false)
+            ->allowedValues(self::AUTO_KEYWORD, true, false)
+            ->default(self::AUTO_KEYWORD)
         ;
 
         return $optionsResolver;

--- a/tests/src/Config/ConfigReaderTest.php
+++ b/tests/src/Config/ConfigReaderTest.php
@@ -306,6 +306,14 @@ final class ConfigReaderTest extends Framework\TestCase
                         ],
                         true,
                     ),
+                    new Src\Config\FileToModify(
+                        'Documentation/guides.xml',
+                        [
+                            'release="{%version%}"',
+                        ],
+                        true,
+                        false,
+                    ),
                 ],
                 $rootPath,
             ),

--- a/tests/src/Config/Preset/Typo3ExtensionPresetTest.php
+++ b/tests/src/Config/Preset/Typo3ExtensionPresetTest.php
@@ -43,6 +43,34 @@ final class Typo3ExtensionPresetTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function getConfigAllowsSpecialAutoKeywordForDocumentation(): void
+    {
+        $subject = new Src\Config\Preset\Typo3ExtensionPreset(['documentation' => 'auto']);
+
+        $expected = new Src\Config\VersionBumperConfig(
+            filesToModify: [
+                new Src\Config\FileToModify(
+                    'ext_emconf.php',
+                    [
+                        new Src\Config\FilePattern("'version' => '{%version%}'"),
+                    ],
+                    true,
+                ),
+                new Src\Config\FileToModify(
+                    'Documentation/guides.xml',
+                    [
+                        new Src\Config\FilePattern('release="{%version%}"'),
+                    ],
+                    true,
+                    false,
+                ),
+            ],
+        );
+
+        self::assertEquals($expected, $subject->getConfig());
+    }
+
+    #[Framework\Attributes\Test]
     public function getConfigReturnsResolvedConfig(): void
     {
         $expected = new Src\Config\VersionBumperConfig(


### PR DESCRIPTION
This PR extends the `documentation` preset option of TYPO3 extension preset by an `auto` keyword. When used, ReST documentation version is automatically updated if it exists. This is also the new default value for this preset option.