### PR TITLE
[FEATURE] Provide config preset for TYPO3 commit guidelines

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -12,11 +12,15 @@ options. The available options differ between presets.
 
 ### Composer package (`composer-package`)
 
+Preset for Composer packages managed by a `composer.json` file.
+
 | Option | Type   | Required | Description                                                                |
 |--------|--------|----------|----------------------------------------------------------------------------|
 | `path` | String | –        | Directory where `composer.json` is located, defaults to current directory. |
 
 ### NPM package (`npm-package`)
+
+Preset for NPM packages managed by a `package.json` file.
 
 | Option        | Type   | Required | Description                                                               |
 |---------------|--------|----------|---------------------------------------------------------------------------|
@@ -25,6 +29,9 @@ options. The available options differ between presets.
 
 ### TYPO3 extension (`typo3-extension`)
 
+Preset for legacy or public TYPO3 extensions managed by an
+`ext_emconf.php` file.
+
 | Option          | Type                                   | Required | Description                                                          |
 |-----------------|----------------------------------------|----------|----------------------------------------------------------------------|
 | `documentation` | Boolean or `auto` keyword<sup>1)</sup> | –        | Define whether or not a ReST documentation is used in the extension. |
@@ -32,6 +39,11 @@ options. The available options differ between presets.
 <sup>1)</sup> By default or if keyword `auto` is used, ReST documentation
 version may be replaced, if existent, but version bumping will not fail if
 a ReST documentation does not exist.
+
+### TYPO3 commit guidelines (`typo3-commit-guidelines`)
+
+Preset for TYPO3 projects which adhere to the
+[Commit Message rules for TYPO3 CMS](https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/Appendix/CommitMessage.html).
 
 ## Example
 

--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -147,6 +147,20 @@
 						"name": {
 							"type": "string",
 							"enum": [
+								"typo3-commit-guidelines"
+							]
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"name"
+					]
+				},
+				{
+					"properties": {
+						"name": {
+							"type": "string",
+							"enum": [
 								"typo3-extension"
 							]
 						},
@@ -185,6 +199,7 @@
 			"description": "Configuration for presets which do not have required preset options",
 			"enum": [
 				"composer-package",
+				"typo3-commit-guidelines",
 				"typo3-extension"
 			]
 		},

--- a/src/Config/Preset/PresetFactory.php
+++ b/src/Config/Preset/PresetFactory.php
@@ -37,6 +37,7 @@ final class PresetFactory
         ComposerPackagePreset::class,
         NpmPackagePreset::class,
         Typo3ExtensionPreset::class,
+        Typo3CommitGuidelinesPreset::class,
     ];
 
     /**

--- a/src/Config/Preset/Typo3CommitGuidelinesPreset.php
+++ b/src/Config/Preset/Typo3CommitGuidelinesPreset.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Config\Preset;
+
+use EliasHaeussler\VersionBumper\Config;
+use EliasHaeussler\VersionBumper\Enum;
+
+/**
+ * Typo3CommitGuidelinesPreset.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @see https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/Appendix/CommitMessage.html
+ */
+final class Typo3CommitGuidelinesPreset implements Preset
+{
+    /* @phpstan-ignore constructor.unusedParameter */
+    public function __construct(array $options = []) {}
+
+    public function getConfig(): Config\VersionBumperConfig
+    {
+        $versionRangeIndicators = [
+            // Major
+            new Config\VersionRangeIndicator(
+                Enum\VersionRange::Major,
+                [
+                    new Config\VersionRangePattern(
+                        Enum\VersionRangeIndicatorType::CommitMessage,
+                        '/^\[!!!]/',
+                    ),
+                ],
+            ),
+
+            // Minor
+            new Config\VersionRangeIndicator(
+                Enum\VersionRange::Minor,
+                [
+                    new Config\VersionRangePattern(
+                        Enum\VersionRangeIndicatorType::CommitMessage,
+                        '/^\[FEATURE]/',
+                    ),
+                ],
+            ),
+
+            // Patch
+            new Config\VersionRangeIndicator(
+                Enum\VersionRange::Patch,
+                [
+                    new Config\VersionRangePattern(
+                        Enum\VersionRangeIndicatorType::CommitMessage,
+                        '/^\[(BUGFIX|DOCS|TASK)]/',
+                    ),
+                ],
+            ),
+        ];
+
+        return new Config\VersionBumperConfig(versionRangeIndicators: $versionRangeIndicators);
+    }
+
+    public static function getIdentifier(): string
+    {
+        return 'typo3-commit-guidelines';
+    }
+
+    public static function getDescription(): string
+    {
+        return 'TYPO3 guidelines for commit messages';
+    }
+}

--- a/tests/src/Config/Preset/Typo3CommitGuidelinesPresetTest.php
+++ b/tests/src/Config/Preset/Typo3CommitGuidelinesPresetTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Config\Preset;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
+
+/**
+ * Typo3CommitGuidelinesPresetTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Config\Preset\Typo3CommitGuidelinesPreset::class)]
+final class Typo3CommitGuidelinesPresetTest extends Framework\TestCase
+{
+    private Src\Config\Preset\Typo3CommitGuidelinesPreset $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Config\Preset\Typo3CommitGuidelinesPreset();
+    }
+
+    #[Framework\Attributes\Test]
+    public function getConfigReturnsResolvedConfig(): void
+    {
+        $expected = new Src\Config\VersionBumperConfig(
+            versionRangeIndicators: [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Major,
+                    [
+                        new Src\Config\VersionRangePattern(
+                            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+                            '/^\[!!!]/',
+                        ),
+                    ],
+                ),
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Minor,
+                    [
+                        new Src\Config\VersionRangePattern(
+                            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+                            '/^\[FEATURE]/',
+                        ),
+                    ],
+                ),
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Patch,
+                    [
+                        new Src\Config\VersionRangePattern(
+                            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+                            '/^\[(BUGFIX|DOCS|TASK)]/',
+                        ),
+                    ],
+                ),
+            ],
+        );
+
+        self::assertEquals($expected, $this->subject->getConfig());
+    }
+}


### PR DESCRIPTION
This PR adds a new `typo3-commit-guidelines` config preset. It can be used in TYPO3 projects or extensions to provide version range auto-detection, based on commit messages formatted using the [Commit Message rules for TYPO3 CMS](https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/Appendix/CommitMessage.html).