### PR TITLE
[BUGFIX] Fix version pattern

### DIFF
--- a/src/Version/Version.php
+++ b/src/Version/Version.php
@@ -37,7 +37,7 @@ use function preg_match;
  */
 final class Version implements Stringable
 {
-    private const VERSION_PATTERN = '/^v?(?P<major>0|[1-9]+)\.(?P<minor>0|[1-9]+)\.(?P<patch>0|[1-9]+)$/';
+    private const VERSION_PATTERN = '/^v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$/';
 
     public function __construct(
         private readonly int $major,


### PR DESCRIPTION
The previous version pattern allowed `0` (zero) only as first character, which is obviously wrong. This is now fixed.