### PR TITLE
[FEATURE] Support legacy TYPO3 documentation rendering

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -32,13 +32,14 @@ Preset for NPM packages managed by a `package.json` file.
 Preset for legacy or public TYPO3 extensions managed by an
 `ext_emconf.php` file.
 
-| Option          | Type                                   | Required | Description                                                          |
-|-----------------|----------------------------------------|----------|----------------------------------------------------------------------|
-| `documentation` | Boolean or `auto` keyword<sup>1)</sup> | –        | Define whether or not a ReST documentation is used in the extension. |
+| Option          | Type                                            | Required | Description                                                          |
+|-----------------|-------------------------------------------------|----------|----------------------------------------------------------------------|
+| `documentation` | Boolean or `auto`/`legacy` keyword<sup>1)</sup> | –        | Define whether or not a ReST documentation is used in the extension. |
 
 <sup>1)</sup> By default or if keyword `auto` is used, ReST documentation
 version may be replaced, if existent, but version bumping will not fail if
-a ReST documentation does not exist.
+a ReST documentation does not exist. If `legacy` keyword is used, legacy
+Sphinx-based rendering documentation files will be used for version bumps.
 
 ### TYPO3 commit guidelines (`typo3-commit-guidelines`)
 

--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -175,11 +175,13 @@
 										{
 											"type": "string",
 											"enum": [
-												"auto"
+												"auto",
+												"legacy"
 											]
 										}
 									],
 									"title": "Define whether extension has a ReST documentation",
+									"description": "Use \"auto\" to automatically detect documentation files (PHP-based or Sphinx-based rendering) or \"legacy\" to use Sphinx-based rendering files.",
 									"default": "auto"
 								}
 							},

--- a/tests/src/Config/ConfigReaderTest.php
+++ b/tests/src/Config/ConfigReaderTest.php
@@ -187,7 +187,7 @@ final class ConfigReaderTest extends Framework\TestCase
         $fileToModify = new Src\Config\FileToModify(
             'baz',
             [
-                'foo: {%version%}',
+                new Src\Config\FilePattern('foo: {%version%}'),
             ],
         );
         $rootPath = dirname(__DIR__).'/Fixtures/RootPath';
@@ -205,7 +205,7 @@ final class ConfigReaderTest extends Framework\TestCase
                     new Src\Config\FileToModify(
                         'foo/composer.json',
                         [
-                            '"version": "{%version%}"',
+                            new Src\Config\FilePattern('"version": "{%version%}"'),
                         ],
                         true,
                     ),
@@ -225,7 +225,7 @@ final class ConfigReaderTest extends Framework\TestCase
                     new Src\Config\FileToModify(
                         'composer.json',
                         [
-                            '"version": "{%version%}"',
+                            new Src\Config\FilePattern('"version": "{%version%}"'),
                         ],
                         true,
                     ),
@@ -248,14 +248,14 @@ final class ConfigReaderTest extends Framework\TestCase
                     new Src\Config\FileToModify(
                         'foo/package.json',
                         [
-                            '"version": "{%version%}"',
+                            new Src\Config\FilePattern('"version": "{%version%}"'),
                         ],
                         true,
                     ),
                     new Src\Config\FileToModify(
                         'foo/package-lock.json',
                         [
-                            '"name": "@foo/baz",\s+"version": "{%version%}"',
+                            new Src\Config\FilePattern('"name": "@foo/baz",\s+"version": "{%version%}"'),
                         ],
                         true,
                     ),
@@ -275,14 +275,14 @@ final class ConfigReaderTest extends Framework\TestCase
                     new Src\Config\FileToModify(
                         'ext_emconf.php',
                         [
-                            "'version' => '{%version%}'",
+                            new Src\Config\FilePattern("'version' => '{%version%}'"),
                         ],
                         true,
                     ),
                     new Src\Config\FileToModify(
                         'Documentation/guides.xml',
                         [
-                            'release="{%version%}"',
+                            new Src\Config\FilePattern('release="{%version%}"'),
                         ],
                         true,
                     ),
@@ -302,14 +302,22 @@ final class ConfigReaderTest extends Framework\TestCase
                     new Src\Config\FileToModify(
                         'ext_emconf.php',
                         [
-                            "'version' => '{%version%}'",
+                            new Src\Config\FilePattern("'version' => '{%version%}'"),
                         ],
                         true,
                     ),
                     new Src\Config\FileToModify(
                         'Documentation/guides.xml',
                         [
-                            'release="{%version%}"',
+                            new Src\Config\FilePattern('release="{%version%}"'),
+                        ],
+                        true,
+                        false,
+                    ),
+                    new Src\Config\FileToModify(
+                        'Documentation/Settings.cfg',
+                        [
+                            new Src\Config\FilePattern('release = {%version%}'),
                         ],
                         true,
                         false,

--- a/tests/src/Config/Preset/Typo3ExtensionPresetTest.php
+++ b/tests/src/Config/Preset/Typo3ExtensionPresetTest.php
@@ -64,6 +64,41 @@ final class Typo3ExtensionPresetTest extends Framework\TestCase
                     true,
                     false,
                 ),
+                new Src\Config\FileToModify(
+                    'Documentation/Settings.cfg',
+                    [
+                        new Src\Config\FilePattern('release = {%version%}'),
+                    ],
+                    true,
+                    false,
+                ),
+            ],
+        );
+
+        self::assertEquals($expected, $subject->getConfig());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getConfigAllowsSpecialLegacyKeywordForDocumentation(): void
+    {
+        $subject = new Src\Config\Preset\Typo3ExtensionPreset(['documentation' => 'legacy']);
+
+        $expected = new Src\Config\VersionBumperConfig(
+            filesToModify: [
+                new Src\Config\FileToModify(
+                    'ext_emconf.php',
+                    [
+                        new Src\Config\FilePattern("'version' => '{%version%}'"),
+                    ],
+                    true,
+                ),
+                new Src\Config\FileToModify(
+                    'Documentation/Settings.cfg',
+                    [
+                        new Src\Config\FilePattern('release = {%version%}'),
+                    ],
+                    true,
+                ),
             ],
         );
 


### PR DESCRIPTION
This PR extends the `typo3-extension` preset by supporting legacy Sphinx-based documentation rendering. For this, the `documentation` preset option now supports a new `legacy` keyword. In addition, support is added when using the `auto` keyword.