### PR TITLE
[BUGFIX] Make `filesToModify` optional in config file

### DIFF
--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -41,9 +41,6 @@
 		}
 	},
 	"additionalProperties": false,
-	"required": [
-		"filesToModify"
-	],
 	"definitions": {
 		"fileToModify": {
 			"type": "object",


### PR DESCRIPTION
With the introduction of config presets, it may become obsolete to provide files to modify. Hence, `filesToModify` must no longer be a required config option.