### PR TITLE
[FEATURE] Add preset for Conventional Commits 1.0.0

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -18,6 +18,12 @@ Preset for Composer packages managed by a `composer.json` file.
 |--------|--------|----------|----------------------------------------------------------------------------|
 | `path` | String | –        | Directory where `composer.json` is located, defaults to current directory. |
 
+### Conventional Commits (`conventional-commits`)
+
+Preset for [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+_This preset is not configurable._
+
 ### NPM package (`npm-package`)
 
 Preset for NPM packages managed by a `package.json` file.
@@ -45,6 +51,8 @@ Sphinx-based rendering documentation files will be used for version bumps.
 
 Preset for TYPO3 projects which adhere to the
 [Commit Message rules for TYPO3 CMS](https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/Appendix/CommitMessage.html).
+
+_This preset is not configurable._
 
 ## Example
 

--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -144,6 +144,7 @@
 						"name": {
 							"type": "string",
 							"enum": [
+								"conventional-commits",
 								"typo3-commit-guidelines"
 							]
 						}
@@ -198,6 +199,7 @@
 			"description": "Configuration for presets which do not have required preset options",
 			"enum": [
 				"composer-package",
+				"conventional-commits",
 				"typo3-commit-guidelines",
 				"typo3-extension"
 			]

--- a/src/Config/Preset/ConventionalCommitsPreset.php
+++ b/src/Config/Preset/ConventionalCommitsPreset.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Config\Preset;
+
+use EliasHaeussler\VersionBumper\Config;
+use EliasHaeussler\VersionBumper\Enum;
+
+/**
+ * ConventionalCommitsPreset.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @see https://www.conventionalcommits.org/en/v1.0.0/
+ */
+final class ConventionalCommitsPreset implements Preset
+{
+    public function getConfig(): Config\VersionBumperConfig
+    {
+        $versionRangeIndicators = [
+            // Major
+            new Config\VersionRangeIndicator(
+                Enum\VersionRange::Major,
+                [
+                    new Config\VersionRangePattern(
+                        Enum\VersionRangeIndicatorType::CommitMessage,
+                        '/^[a-z]+(\([\w\-\.]+\))?!:/',
+                    ),
+                ],
+            ),
+
+            // Minor
+            new Config\VersionRangeIndicator(
+                Enum\VersionRange::Minor,
+                [
+                    new Config\VersionRangePattern(
+                        Enum\VersionRangeIndicatorType::CommitMessage,
+                        '/^feat(\([\w\-\.]+\))?:/',
+                    ),
+                ],
+            ),
+
+            // Patch
+            new Config\VersionRangeIndicator(
+                Enum\VersionRange::Patch,
+                [
+                    new Config\VersionRangePattern(
+                        Enum\VersionRangeIndicatorType::CommitMessage,
+                        '/^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\([\w\-\.]+\))?:/',
+                    ),
+                ],
+            ),
+        ];
+
+        return new Config\VersionBumperConfig(versionRangeIndicators: $versionRangeIndicators);
+    }
+
+    public static function getIdentifier(): string
+    {
+        return 'conventional-commits';
+    }
+
+    public static function getDescription(): string
+    {
+        return 'Conventional Commits 1.0.0';
+    }
+}

--- a/src/Config/Preset/PresetFactory.php
+++ b/src/Config/Preset/PresetFactory.php
@@ -35,6 +35,7 @@ final class PresetFactory
 {
     private const PRESETS = [
         ComposerPackagePreset::class,
+        ConventionalCommitsPreset::class,
         NpmPackagePreset::class,
         Typo3ExtensionPreset::class,
         Typo3CommitGuidelinesPreset::class,

--- a/tests/src/Config/Preset/ConventionalCommitsPresetTest.php
+++ b/tests/src/Config/Preset/ConventionalCommitsPresetTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Config\Preset;
+
+use EliasHaeussler\VersionBumper as Src;
+use EliasHaeussler\VersionBumper\Tests;
+use Generator;
+use PHPUnit\Framework;
+
+use function str_replace;
+
+/**
+ * ConventionalCommitsPresetTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Config\Preset\ConventionalCommitsPreset::class)]
+final class ConventionalCommitsPresetTest extends Framework\TestCase
+{
+    private Src\Config\Preset\ConventionalCommitsPreset $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Config\Preset\ConventionalCommitsPreset();
+    }
+
+    #[Framework\Attributes\Test]
+    public function getConfigReturnsResolvedConfig(): void
+    {
+        $expected = new Src\Config\VersionBumperConfig(
+            versionRangeIndicators: [
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Major,
+                    [
+                        new Src\Config\VersionRangePattern(
+                            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+                            '/^[a-z]+(\([\w\-\.]+\))?!:/',
+                        ),
+                    ],
+                ),
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Minor,
+                    [
+                        new Src\Config\VersionRangePattern(
+                            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+                            '/^feat(\([\w\-\.]+\))?:/',
+                        ),
+                    ],
+                ),
+                new Src\Config\VersionRangeIndicator(
+                    Src\Enum\VersionRange::Patch,
+                    [
+                        new Src\Config\VersionRangePattern(
+                            Src\Enum\VersionRangeIndicatorType::CommitMessage,
+                            '/^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\([\w\-\.]+\))?:/',
+                        ),
+                    ],
+                ),
+            ],
+        );
+
+        self::assertEquals($expected, $this->subject->getConfig());
+    }
+
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('getConfigReturnsConfigWithVersionRangeIndicatorsDataProvider')]
+    public function getConfigReturnsConfigWithVersionRangeIndicators(
+        string $commitMessage,
+        Src\Enum\VersionRange $expected,
+    ): void {
+        $caller = new Tests\Fixtures\Classes\DummyCaller();
+        $versionRangeDetector = new Src\Version\VersionRangeDetector($caller);
+        $indicators = $this->subject->getConfig()->versionRangeIndicators();
+
+        $commit = str_replace(
+            'Hello World!',
+            $commitMessage,
+            (string) file_get_contents(dirname(__DIR__, 2).'/Fixtures/Git/log-commit.txt'),
+        );
+        $tag = str_replace(
+            'Hello World!',
+            $commitMessage,
+            (string) file_get_contents(dirname(__DIR__, 2).'/Fixtures/Git/show-tag.txt'),
+        );
+        $diff = (string) file_get_contents(dirname(__DIR__, 2).'/Fixtures/Git/diff-tag-added.txt');
+
+        $caller->results = [
+            ['1.2.0', 'tag'],
+            ['1.2.0', 'tag'],
+            ['08708bc0b5c07a8233b6510c4677ad3ad112d5d4', "rev-list '-n1' 'refs/tags/1.2.0'"],
+            [$commit, "log '-s' '--pretty=raw' '--no-color' '--max-count=-1' '--skip=0' 'refs/tags/1.2.0..HEAD'"],
+            [$tag, "show '-s' '--pretty=raw' '--no-color' '1.2.0'"],
+            [$diff, "diff '--full-index' '--no-color' '--no-ext-diff' '-M' '--dst-prefix=DST/' '--src-prefix=SRC/' '08708bc0b5c07a8233b6510c4677ad3ad112d5d4^..08708bc0b5c07a8233b6510c4677ad3ad112d5d4'"],
+        ];
+
+        $actual = $versionRangeDetector->detect(__DIR__, $indicators, '1.2.0');
+
+        self::assertSame($expected, $actual);
+    }
+
+    /**
+     * @return Generator<string, array{string, Src\Enum\VersionRange}>
+     */
+    public static function getConfigReturnsConfigWithVersionRangeIndicatorsDataProvider(): Generator
+    {
+        $patchTypes = [
+            'build',
+            'chore',
+            'ci',
+            'docs',
+            'fix',
+            'perf',
+            'refactor',
+            'revert',
+            'style',
+            'test',
+        ];
+
+        yield 'breaking change' => ['feat!: add breaking feature', Src\Enum\VersionRange::Major];
+        yield 'breaking change with scope' => ['feat(foo)!: add breaking feature', Src\Enum\VersionRange::Major];
+        yield 'feature' => ['feat: add non-breaking feature', Src\Enum\VersionRange::Minor];
+        yield 'feature with scope' => ['feat(foo): add non-breaking feature', Src\Enum\VersionRange::Minor];
+
+        foreach ($patchTypes as $patchType) {
+            yield $patchType => [$patchType.': do something', Src\Enum\VersionRange::Patch];
+            yield $patchType.' with scope' => [$patchType.'(foo): do something', Src\Enum\VersionRange::Patch];
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new config presets to provide version range indicators compatible with [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).