### PR TITLE
[FEATURE] Support configuration with PHP file

### DIFF
--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -13,6 +13,7 @@ bumper.
 The following file formats are supported currently:
 
 * `json`
+* `php`
 * `yaml`, `yml`
 
 ## Configuration in `composer.json`
@@ -39,6 +40,7 @@ If no config file is explicitly configured, the config reader
 tries to auto-detect its location. The following order is taken
 into account during auto-detection:
 
-1. `version-bumper.json`
-2. `version-bumper.yaml`
-3. `version-bumper.yml`
+1. `version-bumper.php`
+2. `version-bumper.json`
+3. `version-bumper.yaml`
+4. `version-bumper.yml`

--- a/tests/src/Fixtures/ConfigFiles/invalid-config.php
+++ b/tests/src/Fixtures/ConfigFiles/invalid-config.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */

--- a/tests/src/Fixtures/ConfigFiles/valid-config-with-closure.php
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-with-closure.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use EliasHaeussler\VersionBumper\Config;
+
+return static fn () => new Config\VersionBumperConfig(
+    filesToModify: [
+        new Config\FileToModify(
+            'foo',
+            [
+                new Config\FilePattern('baz: {%version%}'),
+            ],
+        ),
+    ],
+    rootPath: '..',
+);

--- a/tests/src/Fixtures/ConfigFiles/valid-config.php
+++ b/tests/src/Fixtures/ConfigFiles/valid-config.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use EliasHaeussler\VersionBumper\Config;
+
+return new Config\VersionBumperConfig(
+    filesToModify: [
+        new Config\FileToModify(
+            'foo',
+            [
+                new Config\FilePattern('baz: {%version%}'),
+            ],
+        ),
+    ],
+    rootPath: '..',
+);

--- a/tests/src/Fixtures/ConfigFiles/version-bumper.php
+++ b/tests/src/Fixtures/ConfigFiles/version-bumper.php
@@ -1,0 +1,1 @@
+valid-config.php


### PR DESCRIPTION
This PR extends the `ConfigReader` to allow usage of `version-bumper.php` files, for example:

```php
<?php

declare(strict_types=1);

use EliasHaeussler\VersionBumper;

return new VersionBumper\Config\VersionBumperConfig(
    filesToModify: [
        new VersionBumper\Config\FileToModify(
            'foo',
            [
                new VersionBumper\Config\FilePattern('baz: {%version%}'),
            ],
        ),
    ],
    rootPath: '..',
);
```