### PR TITLE
[BUGFIX] Avoid "Skipped" message if other states exist for file

### DIFF
--- a/tests/src/Command/BumpVersionCommandTest.php
+++ b/tests/src/Command/BumpVersionCommandTest.php
@@ -289,8 +289,8 @@ final class BumpVersionCommandTest extends Framework\TestCase
         self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
         self::assertStringContainsString('Bumped version from "1.0.0" to "2.0.0" (2x)', $output);
         self::assertStringContainsString('Unmatched file pattern: foo: {%version%}', $output);
-        self::assertStringContainsString('Skipped file due to unmodified contents', $output);
         self::assertStringContainsString('No write operations were performed (dry-run mode).', $output);
+        self::assertStringNotContainsString('Skipped file due to unmodified contents', $output);
         self::assertStringNotContainsString('foobaz', $output);
     }
 

--- a/tests/src/Fixtures/ConfigFiles/valid-config-with-root-path.json
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-with-root-path.json
@@ -11,6 +11,7 @@
 		{
 			"path": "baz",
 			"patterns": [
+				"baz: {%version%}",
 				"foo: {%version%}"
 			]
 		},


### PR DESCRIPTION
If other states than "Skipped" apply to a modified file, the "Skipped" message should not appear.