### PR TITLE
[FEATURE] Pass root config when merging config from presets

### DIFF
--- a/src/Config/ConfigReader.php
+++ b/src/Config/ConfigReader.php
@@ -83,7 +83,7 @@ final class ConfigReader
         }
 
         foreach ($config->presets() as $preset) {
-            $config = $config->merge($preset->getConfig());
+            $config = $config->merge($preset->getConfig($config));
         }
 
         return $config;

--- a/src/Config/Preset/ComposerPackagePreset.php
+++ b/src/Config/Preset/ComposerPackagePreset.php
@@ -43,7 +43,7 @@ final class ComposerPackagePreset extends BasePreset
         $this->options = $this->resolveOptions($options);
     }
 
-    public function getConfig(): Config\VersionBumperConfig
+    public function getConfig(?Config\VersionBumperConfig $rootConfig = null): Config\VersionBumperConfig
     {
         $filesToModify = [
             new Config\FileToModify(

--- a/src/Config/Preset/ConventionalCommitsPreset.php
+++ b/src/Config/Preset/ConventionalCommitsPreset.php
@@ -36,7 +36,7 @@ use EliasHaeussler\VersionBumper\Enum;
  */
 final class ConventionalCommitsPreset implements Preset
 {
-    public function getConfig(): Config\VersionBumperConfig
+    public function getConfig(?Config\VersionBumperConfig $rootConfig = null): Config\VersionBumperConfig
     {
         $versionRangeIndicators = [
             // Major

--- a/src/Config/Preset/NpmPackagePreset.php
+++ b/src/Config/Preset/NpmPackagePreset.php
@@ -44,7 +44,7 @@ final class NpmPackagePreset extends BasePreset
         $this->options = $this->resolveOptions($options);
     }
 
-    public function getConfig(): Config\VersionBumperConfig
+    public function getConfig(?Config\VersionBumperConfig $rootConfig = null): Config\VersionBumperConfig
     {
         $filesToModify = [
             new Config\FileToModify(

--- a/src/Config/Preset/Preset.php
+++ b/src/Config/Preset/Preset.php
@@ -33,7 +33,7 @@ use EliasHaeussler\VersionBumper\Config;
  */
 interface Preset
 {
-    public function getConfig(): Config\VersionBumperConfig;
+    public function getConfig(?Config\VersionBumperConfig $rootConfig = null): Config\VersionBumperConfig;
 
     public static function getIdentifier(): string;
 

--- a/src/Config/Preset/Typo3CommitGuidelinesPreset.php
+++ b/src/Config/Preset/Typo3CommitGuidelinesPreset.php
@@ -36,7 +36,7 @@ use EliasHaeussler\VersionBumper\Enum;
  */
 final class Typo3CommitGuidelinesPreset implements Preset
 {
-    public function getConfig(): Config\VersionBumperConfig
+    public function getConfig(?Config\VersionBumperConfig $rootConfig = null): Config\VersionBumperConfig
     {
         $versionRangeIndicators = [
             // Major

--- a/src/Config/Preset/Typo3ExtensionPreset.php
+++ b/src/Config/Preset/Typo3ExtensionPreset.php
@@ -46,7 +46,7 @@ final class Typo3ExtensionPreset extends BasePreset
         $this->options = $this->resolveOptions($options);
     }
 
-    public function getConfig(): Config\VersionBumperConfig
+    public function getConfig(?Config\VersionBumperConfig $rootConfig = null): Config\VersionBumperConfig
     {
         $reportMissingFile = self::AUTO_KEYWORD !== $this->options['documentation'];
         $filesToModify = [

--- a/tests/src/Fixtures/Classes/DummyPreset.php
+++ b/tests/src/Fixtures/Classes/DummyPreset.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\VersionBumper\Tests\Fixtures\Classes;
 
 use EliasHaeussler\VersionBumper\Config;
-use EliasHaeussler\VersionBumper\Config\Preset\BasePreset;
 use Symfony\Component\OptionsResolver;
 
 /**
@@ -35,16 +34,16 @@ use Symfony\Component\OptionsResolver;
  *
  * @internal
  *
- * @extends BasePreset<array<string, mixed>>
+ * @extends Config\Preset\BasePreset<array<string, mixed>>
  */
-final class DummyPreset extends BasePreset
+final class DummyPreset extends Config\Preset\BasePreset
 {
     public function __construct(array $options = [])
     {
         $this->options = $options;
     }
 
-    public function getConfig(): Config\VersionBumperConfig
+    public function getConfig(?Config\VersionBumperConfig $rootConfig = null): Config\VersionBumperConfig
     {
         return new Config\VersionBumperConfig();
     }


### PR DESCRIPTION
This pull request introduces changes to enhance the flexibility of the `getConfig` method across various preset classes and interfaces by allowing it to accept an optional `VersionBumperConfig` parameter. Additionally, it includes minor adjustments to improve code clarity and consistency.

### Enhancements to `getConfig` method:

* Updated `getConfig` method in the `Preset` interface to accept an optional `VersionBumperConfig` parameter for better configurability. (`src/Config/Preset/Preset.php`)
* Modified `getConfig` implementations in multiple preset classes (`ComposerPackagePreset`, `ConventionalCommitsPreset`, `NpmPackagePreset`, `Typo3CommitGuidelinesPreset`, `Typo3ExtensionPreset`, and `DummyPreset`) to align with the updated interface and utilize the optional parameter. (`src/Config/Preset/ComposerPackagePreset.php` [[1]](diffhunk://#diff-016e349b0a6e7822678a50eccda72bfe00cf8bf80802c782c4bd0740880039f7L46-R46) `src/Config/Preset/ConventionalCommitsPreset.php` [[2]](diffhunk://#diff-4841144da6cd0da27798cde602c867a90e58ba6d7e5ce762360d353bb0bc7c6dL39-R39) `src/Config/Preset/NpmPackagePreset.php` [[3]](diffhunk://#diff-d6b99d45f584941f242870e0ef35d8b149194052cc0f928d6f1f4d1f2d0814f8L47-R47) `src/Config/Preset/Typo3CommitGuidelinesPreset.php` [[4]](diffhunk://#diff-363163da34073270ad5e46379b620c847c7a1d18961058a04648588c250c6136L39-R39) `src/Config/Preset/Typo3ExtensionPreset.php` [[5]](diffhunk://#diff-bd1b67c691543da56095533a7cbc7a07c391a405c68ccf014cf0d804a6012811L49-R49) `tests/src/Fixtures/Classes/DummyPreset.php` [[6]](diffhunk://#diff-af0a61ea28e54f84f129124dc7831edd9a624dc1e9380b34b4bd64cf91cdb30cL38-R46))

### Code clarity improvements:

* Adjusted the `readFromFile` method in `ConfigReader` to pass the current configuration to the `getConfig` method for merging preset configurations. (`src/Config/ConfigReader.php`)
* Refactored `DummyPreset` to explicitly reference `Config\Preset\BasePreset` for improved readability and consistency. (`tests/src/Fixtures/Classes/DummyPreset.php`)