### PR TITLE
[FEATURE] Retain version suffixes in TYPO3 extension version

### DIFF
--- a/src/Config/Preset/Typo3ExtensionPreset.php
+++ b/src/Config/Preset/Typo3ExtensionPreset.php
@@ -61,7 +61,8 @@ final class Typo3ExtensionPreset extends BasePreset
             new Config\FileToModify(
                 'composer.json',
                 [
-                    new Config\FilePattern('"version": "{%version%}"'),
+                    // Missing trailing quote is intended to allow and retain version suffixes (e.g. "1.0.0-dev" or "1.0.0+obsolete")
+                    new Config\FilePattern('"version": "{%version%}'),
                 ],
                 true,
             ),

--- a/tests/src/Config/ConfigReaderTest.php
+++ b/tests/src/Config/ConfigReaderTest.php
@@ -334,7 +334,7 @@ final class ConfigReaderTest extends Framework\TestCase
                     new Src\Config\FileToModify(
                         'composer.json',
                         [
-                            new Src\Config\FilePattern('"version": "{%version%}"'),
+                            new Src\Config\FilePattern('"version": "{%version%}'),
                         ],
                         true,
                     ),
@@ -368,7 +368,7 @@ final class ConfigReaderTest extends Framework\TestCase
                     new Src\Config\FileToModify(
                         'composer.json',
                         [
-                            new Src\Config\FilePattern('"version": "{%version%}"'),
+                            new Src\Config\FilePattern('"version": "{%version%}'),
                         ],
                         true,
                     ),

--- a/tests/src/Config/Preset/Typo3ExtensionPresetTest.php
+++ b/tests/src/Config/Preset/Typo3ExtensionPresetTest.php
@@ -26,6 +26,8 @@ namespace EliasHaeussler\VersionBumper\Tests\Config\Preset;
 use EliasHaeussler\VersionBumper as Src;
 use PHPUnit\Framework;
 
+use function json_encode;
+
 /**
  * Typo3ExtensionPresetTest.
  *
@@ -59,7 +61,7 @@ final class Typo3ExtensionPresetTest extends Framework\TestCase
                 new Src\Config\FileToModify(
                     'composer.json',
                     [
-                        new Src\Config\FilePattern('"version": "{%version%}"'),
+                        new Src\Config\FilePattern('"version": "{%version%}'),
                     ],
                     true,
                 ),
@@ -102,7 +104,7 @@ final class Typo3ExtensionPresetTest extends Framework\TestCase
                 new Src\Config\FileToModify(
                     'composer.json',
                     [
-                        new Src\Config\FilePattern('"version": "{%version%}"'),
+                        new Src\Config\FilePattern('"version": "{%version%}'),
                     ],
                     true,
                 ),
@@ -134,7 +136,7 @@ final class Typo3ExtensionPresetTest extends Framework\TestCase
                 new Src\Config\FileToModify(
                     'composer.json',
                     [
-                        new Src\Config\FilePattern('"version": "{%version%}"'),
+                        new Src\Config\FilePattern('"version": "{%version%}'),
                     ],
                     true,
                 ),
@@ -149,5 +151,41 @@ final class Typo3ExtensionPresetTest extends Framework\TestCase
         );
 
         self::assertEquals($expected, $this->subject->getConfig());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getConfigReturnsConfigThatKeepsVersionSuffixInComposerJsonOnVersionBump(): void
+    {
+        $versionBumper = new Src\Version\VersionBumper();
+        $config = $this->subject->getConfig();
+        $composerFile = $config->filesToModify()[1];
+
+        self::assertSame('composer.json', $composerFile->path());
+
+        $rootPath = dirname(__DIR__, 2).'/Fixtures/RootPath';
+        $contentBackup = file_get_contents($composerFile->fullPath($rootPath));
+
+        self::assertIsString($contentBackup);
+
+        try {
+            $expected = json_encode(
+                [
+                    'version' => '1.1.0',
+                    'extra' => [
+                        'typo3/cms' => [
+                            'version' => '1.1.0+obsolete',
+                        ],
+                    ],
+                ],
+                JSON_THROW_ON_ERROR,
+            );
+
+            $actual = $versionBumper->bump([$composerFile], $rootPath, Src\Enum\VersionRange::Minor);
+
+            self::assertCount(1, $actual);
+            self::assertJsonStringEqualsJsonFile($composerFile->fullPath($rootPath), $expected);
+        } finally {
+            file_put_contents($composerFile->fullPath($rootPath), $contentBackup);
+        }
     }
 }

--- a/tests/src/Fixtures/RootPath/composer.json
+++ b/tests/src/Fixtures/RootPath/composer.json
@@ -1,3 +1,8 @@
 {
-	"version": "1.0.0"
+	"version": "1.0.0",
+	"extra": {
+		"typo3/cms": {
+			"version": "1.0.0+obsolete"
+		}
+	}
 }

--- a/tests/src/Fixtures/RootPath/composer.lock
+++ b/tests/src/Fixtures/RootPath/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c441a8c09bf696569b4f4f22512ae18",
+    "content-hash": "5483d058a017693e942197e3d8f53714",
     "packages": [],
     "packages-dev": [],
     "aliases": [],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version strings with suffixes (such as dev or obsolete qualifiers) are now properly preserved when updating configuration files.

* **Tests**
  * Added test coverage for version suffix handling during configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->