### PR TITLE
[TASK] Collect and display deprecated config options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
 		"phpstan/phpstan-phpunit": "^2.0",
 		"phpstan/phpstan-symfony": "^2.0",
 		"phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
-		"shipmonk/composer-dependency-analyser": "^1.8"
+		"shipmonk/composer-dependency-analyser": "^1.8",
+		"symfony/deprecation-contracts": "^2.5 || ^3.0"
 	},
 	"conflict": {
 		"cuyz/valinor": "2.2.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20ba250ec9f85b5c3891c350c43b1c19",
+    "content-hash": "743e58cd8d01ca1ea8778db61f0aac0a",
     "packages": [
         {
             "name": "cuyz/valinor",

--- a/src/Command/BumpVersionCommand.php
+++ b/src/Command/BumpVersionCommand.php
@@ -29,6 +29,7 @@ use CuyZ\Valinor;
 use EliasHaeussler\TaskRunner;
 use EliasHaeussler\VersionBumper\Config;
 use EliasHaeussler\VersionBumper\Enum;
+use EliasHaeussler\VersionBumper\Error;
 use EliasHaeussler\VersionBumper\Exception;
 use EliasHaeussler\VersionBumper\Result;
 use EliasHaeussler\VersionBumper\Version;
@@ -46,6 +47,8 @@ use function implode;
 use function is_string;
 use function method_exists;
 use function reset;
+use function restore_error_handler;
+use function set_error_handler;
 use function sprintf;
 use function trim;
 use function usort;
@@ -64,6 +67,11 @@ final class BumpVersionCommand extends Command\BaseCommand
     private readonly Version\VersionReleaser $releaser;
     private Console\Style\SymfonyStyle $io;
     private TaskRunner\TaskRunner $taskRunner;
+
+    /**
+     * @var list<Error\DeprecationMessage>
+     */
+    private array $deprecations = [];
 
     public function __construct(
         ?Composer $composer = null,
@@ -126,6 +134,7 @@ final class BumpVersionCommand extends Command\BaseCommand
     {
         $this->io = new Console\Style\SymfonyStyle($input, $output);
         $this->taskRunner = new TaskRunner\TaskRunner($this->io);
+        $this->deprecations = [];
     }
 
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
@@ -148,6 +157,9 @@ final class BumpVersionCommand extends Command\BaseCommand
         } else {
             $rootPath = dirname($configFile);
         }
+
+        // Register custom error handler to collect deprecations from config presets
+        set_error_handler($this->collectDeprecations(...), E_USER_DEPRECATED);
 
         try {
             $config = $this->configReader->readFromFile($configFile);
@@ -177,9 +189,14 @@ final class BumpVersionCommand extends Command\BaseCommand
 
             return self::FAILURE;
         } finally {
+            // Restore original error handler
+            restore_error_handler();
+
             if ($dryRun) {
                 $this->io->note('No write operations were performed (dry-run mode).');
             }
+
+            $this->decorateDeprecationMessages();
         }
 
         if ($strict) {
@@ -372,6 +389,30 @@ final class BumpVersionCommand extends Command\BaseCommand
         }
     }
 
+    private function decorateDeprecationMessages(): void
+    {
+        if ([] === $this->deprecations) {
+            return;
+        }
+
+        $this->io->warning('Your config file contains deprecated options.');
+
+        $this->io->listing(
+            array_map(
+                static fn (Error\DeprecationMessage $deprecation) => implode('', [
+                    $deprecation->origin() instanceof Config\Preset\Preset
+                        ? sprintf('<fg=yellow>%s</>: ', $deprecation->origin()::getIdentifier())
+                        : '',
+                    $deprecation->message(),
+                    null !== $deprecation->since()
+                        ? sprintf(' <fg=yellow>(deprecated since v%s)</>', $deprecation->since())
+                        : '',
+                ]),
+                $this->deprecations,
+            ),
+        );
+    }
+
     /**
      * @param list<Config\Preset\Preset> $presets
      */
@@ -512,6 +553,18 @@ final class BumpVersionCommand extends Command\BaseCommand
         }
 
         return null;
+    }
+
+    private function collectDeprecations(int $errno, string $errstr): bool
+    {
+        $deprecationMessage = Error\DeprecationMessage::fromTraceOrMessage($errstr);
+        $collected = null !== $deprecationMessage;
+
+        if ($collected) {
+            $this->deprecations[] = $deprecationMessage;
+        }
+
+        return $collected;
     }
 
     private function getComposerInstance(): ?Composer

--- a/src/Error/DeprecationMessage.php
+++ b/src/Error/DeprecationMessage.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Error;
+
+use function count;
+use function debug_backtrace;
+use function explode;
+use function is_array;
+use function is_object;
+use function is_string;
+use function str_contains;
+use function str_starts_with;
+use function substr;
+use function trim;
+
+/**
+ * DeprecationMessage.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final readonly class DeprecationMessage
+{
+    public function __construct(
+        private string $message,
+        private ?string $since = null,
+        private ?object $origin = null,
+    ) {}
+
+    /**
+     * @param array{function?: string, args?: list<mixed>} $trace
+     */
+    public static function fromTrace(array $trace): ?self
+    {
+        if ('trigger_deprecation' !== ($trace['function'] ?? null)) {
+            return null;
+        }
+
+        if (!is_array($trace['args'] ?? null) || count($trace['args']) < 3) {
+            return null;
+        }
+
+        [$packageName, $since, $message] = $trace['args'];
+
+        if ('eliashaeussler/version-bumper' !== $packageName || !is_string($since) || !is_string($message)) {
+            return null;
+        }
+
+        return new self($message, $since);
+    }
+
+    public static function fromMessage(string $message): ?self
+    {
+        $initialPhrase = 'Since eliashaeussler/version-bumper';
+
+        if (!str_starts_with($message, $initialPhrase)) {
+            return null;
+        }
+
+        if (!str_contains($message, ':')) {
+            return new self($message);
+        }
+
+        [$since, $message] = explode(':', substr($message, strlen($initialPhrase)), 2);
+
+        return new self(trim($message), trim($since));
+    }
+
+    public static function fromTraceOrMessage(string $message): ?self
+    {
+        $trace = debug_backtrace();
+        $deprecation = null;
+
+        foreach ($trace as $entry) {
+            if (null === $deprecation) {
+                if ('trigger_deprecation' === $entry['function'] && !isset($entry['class']) && isset($entry['args'])) {
+                    $deprecation = self::fromTrace($entry) ?? self::fromMessage($message);
+                }
+            } elseif (
+                is_object($entry['object'] ?? null)
+                && str_starts_with($entry['class'] ?? '', 'EliasHaeussler\\VersionBumper\\')
+            ) {
+                return $deprecation->withOrigin($entry['object']);
+            }
+        }
+
+        return $deprecation ?? self::fromMessage($message);
+    }
+
+    public function message(): string
+    {
+        return $this->message;
+    }
+
+    public function since(): ?string
+    {
+        return $this->since;
+    }
+
+    public function origin(): ?object
+    {
+        return $this->origin;
+    }
+
+    /**
+     * @impure
+     */
+    public function withOrigin(object $origin): self
+    {
+        return new self($this->message, $this->since, $origin);
+    }
+}

--- a/tests/src/Command/BumpVersionCommandTest.php
+++ b/tests/src/Command/BumpVersionCommandTest.php
@@ -539,6 +539,24 @@ final class BumpVersionCommandTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function executeCollectsAndDisplaysDeprecatedConfigOptions(): void
+    {
+        $configFile = dirname(__DIR__).'/Fixtures/ConfigFiles/valid-config-with-deprecated-config.json';
+
+        $this->commandTester->execute([
+            'range' => '2.0.0',
+            '--config' => $configFile,
+            '--dry-run' => true,
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
+        self::assertStringContainsString('Your config file contains deprecated options.', $output);
+        self::assertStringContainsString('The option "packageName" is no longer needed and should be omitted.', $output);
+    }
+
+    #[Framework\Attributes\Test]
     public function executeUpdatesComposerLockFileIfRequested(): void
     {
         $filesystem = new Filesystem\Filesystem();

--- a/tests/src/Error/DeprecationMessageTest.php
+++ b/tests/src/Error/DeprecationMessageTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/version-bumper".
+ *
+ * Copyright (C) 2024-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\VersionBumper\Tests\Error;
+
+use EliasHaeussler\VersionBumper as Src;
+use PHPUnit\Framework;
+
+use function restore_error_handler;
+use function set_error_handler;
+use function trigger_deprecation;
+
+/**
+ * DeprecationMessageTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Error\DeprecationMessage::class)]
+final class DeprecationMessageTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function fromTraceReturnsNullOnMissingFunction(): void
+    {
+        self::assertNull(Src\Error\DeprecationMessage::fromTrace([]));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromTraceReturnsNullOnUnsupportedFunction(): void
+    {
+        $trace = [
+            'function' => 'foo',
+        ];
+
+        self::assertNull(Src\Error\DeprecationMessage::fromTrace($trace));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromTraceReturnsNullOnMissingArguments(): void
+    {
+        $trace = [
+            'function' => 'trigger_deprecation',
+        ];
+
+        self::assertNull(Src\Error\DeprecationMessage::fromTrace($trace));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromTraceReturnsNullOnInvalidNumberOfArguments(): void
+    {
+        $trace = [
+            'function' => 'trigger_deprecation',
+            'args' => [],
+        ];
+
+        self::assertNull(Src\Error\DeprecationMessage::fromTrace($trace));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromTraceReturnsNullOnUnsupportedPackageNameArgument(): void
+    {
+        $trace = [
+            'function' => 'trigger_deprecation',
+            'args' => [
+                'foo/bar',
+                '4.0.0',
+                'Option "foo" is deprecated.',
+            ],
+        ];
+
+        self::assertNull(Src\Error\DeprecationMessage::fromTrace($trace));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromTraceReturnsNullOnInvalidSinceArgument(): void
+    {
+        $trace = [
+            'function' => 'trigger_deprecation',
+            'args' => [
+                'eliashaeussler/version-bumper',
+                null,
+                'Option "foo" is deprecated.',
+            ],
+        ];
+
+        self::assertNull(Src\Error\DeprecationMessage::fromTrace($trace));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromTraceReturnsNullOnInvalidMessageArgument(): void
+    {
+        $trace = [
+            'function' => 'trigger_deprecation',
+            'args' => [
+                'eliashaeussler/version-bumper',
+                '4.0.0',
+                null,
+            ],
+        ];
+
+        self::assertNull(Src\Error\DeprecationMessage::fromTrace($trace));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromTraceReturnsDeprecationMessageObject(): void
+    {
+        $trace = [
+            'function' => 'trigger_deprecation',
+            'args' => [
+                'eliashaeussler/version-bumper',
+                '4.0.0',
+                'Option "foo" is deprecated.',
+            ],
+        ];
+
+        $expected = new Src\Error\DeprecationMessage('Option "foo" is deprecated.', '4.0.0');
+
+        self::assertEquals($expected, Src\Error\DeprecationMessage::fromTrace($trace));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromMessageReturnsNullOnInvalidMessagePrefix(): void
+    {
+        self::assertNull(Src\Error\DeprecationMessage::fromMessage('foo'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromMessageReturnsMessageWithoutInitialVersion(): void
+    {
+        $message = 'Since eliashaeussler/version-bumper, option "foo" is deprecated.';
+
+        $expected = new Src\Error\DeprecationMessage($message);
+
+        self::assertEquals($expected, Src\Error\DeprecationMessage::fromMessage($message));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromMessageReturnsMessageAndInitialVersion(): void
+    {
+        $message = 'Since eliashaeussler/version-bumper 4.0.0: Option "foo" is deprecated.';
+
+        $expected = new Src\Error\DeprecationMessage('Option "foo" is deprecated.', '4.0.0');
+
+        self::assertEquals($expected, Src\Error\DeprecationMessage::fromMessage($message));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromTraceOrMessageReturnsNullOnMissingDeprecationTriggerAndUnsupportedMessage(): void
+    {
+        self::assertNull(Src\Error\DeprecationMessage::fromTraceOrMessage('Option "foo" is deprecated.'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromTraceOrMessageReturnsMessageOnMissingDeprecationTriggerAndSupportedMessage(): void
+    {
+        $message = 'Since eliashaeussler/version-bumper 4.0.0: Option "foo" is deprecated.';
+
+        $expected = new Src\Error\DeprecationMessage('Option "foo" is deprecated.', '4.0.0');
+
+        self::assertEquals($expected, Src\Error\DeprecationMessage::fromTraceOrMessage($message));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromTraceOrMessageReturnsMessageFromValidTrace(): void
+    {
+        $actual = null;
+
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$actual) {
+                $actual = Src\Error\DeprecationMessage::fromTraceOrMessage($errstr);
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        trigger_deprecation(
+            'eliashaeussler/version-bumper',
+            '4.0.0',
+            'Option "foo" is deprecated.',
+        );
+
+        restore_error_handler();
+
+        $expected = new Src\Error\DeprecationMessage('Option "foo" is deprecated.', '4.0.0', $this);
+
+        self::assertEquals($expected, $actual);
+    }
+}

--- a/tests/src/Fixtures/ConfigFiles/valid-config-with-deprecated-config.json
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-with-deprecated-config.json
@@ -1,0 +1,11 @@
+{
+	"presets": [
+		{
+			"name": "npm-package",
+			"options": {
+				"packageName": "@foo/baz"
+			}
+		}
+	],
+	"rootPath": "../RootPath"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The version bump command now automatically collects and displays any deprecation warnings encountered during execution, presenting them in a clearly formatted list.
  * Each deprecation includes the warning message, timeline details, and source context when available.
  * This provides improved visibility into features that may be deprecated or require future attention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->