### PR TITLE
[BUGFIX] Let user-defined config win over preset values

### DIFF
--- a/src/Config/ConfigReader.php
+++ b/src/Config/ConfigReader.php
@@ -84,7 +84,9 @@ final readonly class ConfigReader
         }
 
         foreach ($config->presets() as $preset) {
-            $config = $config->merge($preset->getConfig($config));
+            // Merge user config on top of preset defaults so that explicit
+            // user values (e.g. releaseOptions, rootPath) win over preset values.
+            $config = $preset->getConfig($config)->merge($config);
         }
 
         return $config;

--- a/tests/src/Config/ConfigReaderTest.php
+++ b/tests/src/Config/ConfigReaderTest.php
@@ -240,7 +240,6 @@ final class ConfigReaderTest extends Framework\TestCase
                     ]),
                 ],
                 [
-                    $fileToModify,
                     new Src\Config\FileToModify(
                         'foo/composer.json',
                         [
@@ -253,6 +252,7 @@ final class ConfigReaderTest extends Framework\TestCase
                             new Src\Version\Action\ComposerLockAction(),
                         ],
                     ),
+                    $fileToModify,
                 ],
                 $rootPath,
             ),
@@ -265,7 +265,6 @@ final class ConfigReaderTest extends Framework\TestCase
                     new Src\Config\Preset\ComposerPackagePreset(),
                 ],
                 [
-                    $fileToModify,
                     new Src\Config\FileToModify(
                         'composer.json',
                         [
@@ -278,6 +277,7 @@ final class ConfigReaderTest extends Framework\TestCase
                             new Src\Version\Action\ComposerLockAction(),
                         ],
                     ),
+                    $fileToModify,
                 ],
                 $rootPath,
             ),
@@ -292,7 +292,6 @@ final class ConfigReaderTest extends Framework\TestCase
                     ]),
                 ],
                 [
-                    $fileToModify,
                     new Src\Config\FileToModify(
                         'foo/package.json',
                         [
@@ -305,6 +304,7 @@ final class ConfigReaderTest extends Framework\TestCase
                             new Src\Version\Action\PackageLockAction(),
                         ],
                     ),
+                    $fileToModify,
                 ],
                 $rootPath,
             ),
@@ -317,7 +317,6 @@ final class ConfigReaderTest extends Framework\TestCase
                     new Src\Config\Preset\Typo3ExtensionPreset(['documentation' => true]),
                 ],
                 [
-                    $fileToModify,
                     new Src\Config\FileToModify(
                         'ext_emconf.php',
                         [
@@ -344,6 +343,7 @@ final class ConfigReaderTest extends Framework\TestCase
                         ],
                         true,
                     ),
+                    $fileToModify,
                 ],
                 $rootPath,
                 new Src\Config\ReleaseOptions('[RELEASE] Release of EXT:foo {%version%}'),
@@ -357,7 +357,6 @@ final class ConfigReaderTest extends Framework\TestCase
                     new Src\Config\Preset\Typo3ExtensionPreset(),
                 ],
                 [
-                    $fileToModify,
                     new Src\Config\FileToModify(
                         'ext_emconf.php',
                         [
@@ -393,6 +392,7 @@ final class ConfigReaderTest extends Framework\TestCase
                         true,
                         false,
                     ),
+                    $fileToModify,
                 ],
                 $rootPath,
                 new Src\Config\ReleaseOptions('[RELEASE] Release of EXT:foo {%version%}'),
@@ -408,6 +408,20 @@ final class ConfigReaderTest extends Framework\TestCase
         $file = $rootPath.'/valid-config-with-'.$preset.'-preset.json';
 
         self::assertEquals($expected, $this->subject->readFromFile($file));
+    }
+
+    #[Framework\Attributes\Test]
+    public function readFromFileKeepsUserDefinedReleaseOptionsWhenPresetProvidesOwnOptions(): void
+    {
+        $rootPath = dirname(__DIR__).'/Fixtures/ConfigFiles';
+        $file = $rootPath.'/valid-config-with-typo3-extension-preset-and-custom-release-options.json';
+
+        $config = $this->subject->readFromFile($file);
+
+        self::assertSame(
+            'release: version {%version%}',
+            $config->releaseOptions()->commitMessage(),
+        );
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Fixtures/ConfigFiles/valid-config-with-typo3-extension-preset-and-custom-release-options.json
+++ b/tests/src/Fixtures/ConfigFiles/valid-config-with-typo3-extension-preset-and-custom-release-options.json
@@ -1,0 +1,17 @@
+{
+	"presets": [
+		"typo3-extension"
+	],
+	"filesToModify": [
+		{
+			"path": "baz",
+			"patterns": [
+				"foo: {%version%}"
+			]
+		}
+	],
+	"releaseOptions": {
+		"commitMessage": "release: version {%version%}"
+	},
+	"rootPath": "../RootPath"
+}


### PR DESCRIPTION
## Problem

When a user configures both a preset and explicit options, preset values silently overwrite the user's configuration. For example, with this `version-bumper.yaml`:

~~~yaml
presets:
  - name: typo3-extension

releaseOptions:
  commitMessage: 'release: version {%version%}'
~~~

…the resulting commit message is `[RELEASE] Release of EXT:<key> …` (from `Typo3ExtensionPreset::buildReleaseOptions()`) instead of the user-defined `release: version …`.

## Cause

`ConfigReader::readFromFile()` merged the preset config on top of the user config:

~~~php
$config = $config->merge($preset->getConfig($config));
~~~

`VersionBumperConfig::merge()` is designed so that `$other` (here the preset) wins over `$this` (here the user) whenever `$other` differs from the default. As a result, any non-default value coming from a preset overrides the user's explicit configuration.

Only `Typo3ExtensionPreset` currently builds non-default `ReleaseOptions`, so this is where the issue surfaces today — but the precedence problem is structural and would apply to any future preset that sets non-array properties.

## Fix

Swap the merge direction so the preset acts as a defaults layer and the user config wins:

~~~php
$config = $preset->getConfig($config)->merge($config);
~~~

`VersionBumperConfig::merge()` itself is untouched, so its existing semantics (`$other` wins, arrays are merged) remain intact.

## Notes

- The order of `filesToModify` after applying a preset changes: preset files now come first, user files last. This is a side effect of `array_merge` order and only affects the iteration order during bumping — not correctness. Existing `ConfigReaderTest` expectations were updated accordingly.
- Added a regression test (`readFromFileKeepsUserDefinedReleaseOptionsWhenPresetProvidesOwnOptions`) plus a fixture combining the `typo3-extension` preset with a custom `releaseOptions.commitMessage`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration merging to ensure user-defined values properly take precedence over preset defaults, including release options and root paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->