### PR TITLE
[DOCS] Document how to bump to the first stable release from an unstable version

### DIFF
--- a/docs/version-range.md
+++ b/docs/version-range.md
@@ -6,6 +6,19 @@
 > number (`0.1.2` → `0.2.0`) and bumping minor version
 > increases the third version number (`0.1.2` → `0.1.3`).
 
+## Bumping to the first stable release
+
+The `major` range cannot produce `1.0.0` from an unstable version, since it
+increases the second digit (`0.5.0` → `0.6.0`). Pass the target version
+explicitly instead:
+
+```bash
+composer bump-version 1.0.0 --release
+```
+
+Version range auto-detection cannot produce `1.0.0` either, as it always
+resolves to a version range.
+
 ## Auto-detection
 
 Normally, an explicit version range or version is passed to

--- a/docs/version-range.md
+++ b/docs/version-range.md
@@ -1,19 +1,25 @@
 # Version range
 
-> [!IMPORTANT]
-> Unstable versions (< `1.0.0`) are handled differently.
-> Bumping major version increases the second version
-> number (`0.1.2` → `0.2.0`) and bumping minor version
-> increases the third version number (`0.1.2` → `0.1.3`).
+## Stable vs. unstable versions
 
-## Bumping to the first stable release
+> [!IMPORTANT]
+> Unstable versions (< `1.0.0`) are handled differently than stable
+> ones (>= `1.0.0`).
+
+### Bumping unstable versions
+
+Bumping an unstable major version increases the second version number
+(`0.1.2` → `0.2.0`) and bumping an unstable minor version increases the
+third version number (`0.1.2` → `0.1.3`).
+
+### Bumping to the first stable release
 
 The `major` range cannot produce `1.0.0` from an unstable version, since it
 increases the second digit (`0.5.0` → `0.6.0`). Pass the target version
 explicitly instead:
 
 ```bash
-composer bump-version 1.0.0 --release
+composer bump-version 1.0.0
 ```
 
 Version range auto-detection cannot produce `1.0.0` either, as it always


### PR DESCRIPTION
## Summary

`docs/version-range.md` and `docs/cli.md` each describe half of this case without connecting them: unstable versions (`< 1.0.0`) bump the second digit (`0.1.2` → `0.2.0`), and `<range>` also accepts an explicit version. What was missing: `major` can never produce `1.0.0` from an unstable version, and neither can version range auto-detection, since it always resolves to a range rather than an explicit version. The only path is passing the target version explicitly.

- Add a "Bumping to the first stable release" section to `docs/version-range.md`, directly below the existing unstable version callout
- State that `major` cannot produce `1.0.0` and that the explicit version (`composer bump-version 1.0.0 --release`) is the way to release it
- State that version range auto-detection cannot produce `1.0.0` either

Closes #164