### PR TITLE
[FEATURE] Add option to release without creating a Git tag

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -23,6 +23,7 @@ filesToModify:
 
 releaseOptions:
   commitMessage: '[RELEASE] Release of my-fancy-library {%version%}'
+  createTag: true
   overwriteExistingTag: true
   signTag: true
   tagName: 'v{%version%}'
@@ -78,6 +79,7 @@ preset identifier only) or using object syntax (provide identifier and options).
 |---------------------------------------|---------|----------|-------------------------------------------------------------------------------------------------------------------------------------|
 | `releaseOptions`                      | Object  | –        | Set of configuration options to respect when a new release is created (using the `--release` command option).                       |
 | `releaseOptions.commitMessage`        | String  | –        | Commit message pattern to use for new releases. May contain a `{%version%}` placeholder that is replaced by the version to release. |
+| `releaseOptions.createTag`            | Boolean | –        | Create a Git tag for the release. If set to `false`, no Git tag is created and only the release commit is performed. Defaults to `true`. |
 | `releaseOptions.overwriteExistingTag` | Boolean | –        | Overwrite an existing tag by deleting it before a new tag is created.                                                               |
 | `releaseOptions.signTag`              | Boolean | –        | Use Git's `-s` command option to sign the new tag using the Git-configured signing key.                                             |
 | `releaseOptions.tagName`              | String  | –        | Tag name pattern to use for new releases. Must contain a `{%version%}` placeholder that is replaced by the version to release.      |

--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -227,7 +227,8 @@
 				"createTag": {
 					"type": "boolean",
 					"title": "Define whether to create a Git tag for the release",
-					"description": "If set to `false`, no Git tag is created and only the release commit is performed."
+					"description": "If set to `false`, no Git tag is created and only the release commit is performed.",
+					"default": true
 				},
 				"overwriteExistingTag": {
 					"type": "boolean",

--- a/res/version-bumper.schema.json
+++ b/res/version-bumper.schema.json
@@ -224,6 +224,11 @@
 					"title": "Commit message pattern to use for new releases",
 					"description": "May contain a `{%version%}` placeholder that is replaced by the version to release."
 				},
+				"createTag": {
+					"type": "boolean",
+					"title": "Define whether to create a Git tag for the release",
+					"description": "If set to `false`, no Git tag is created and only the release commit is performed."
+				},
 				"overwriteExistingTag": {
 					"type": "boolean",
 					"title": "Define whether existing tags should be overwritten",

--- a/src/Command/BumpVersionCommand.php
+++ b/src/Command/BumpVersionCommand.php
@@ -547,7 +547,9 @@ final class BumpVersionCommand extends Command\BaseCommand
             $releaseInformation[] = sprintf('Commit hash: <info>%s</info>', $result->commitId());
         }
 
-        $releaseInformation[] = sprintf('Tagged: <info>%s</info>', $result->tagName());
+        if (null !== $result->tagName()) {
+            $releaseInformation[] = sprintf('Tagged: <info>%s</info>', $result->tagName());
+        }
 
         $this->io->listing($releaseInformation);
     }

--- a/src/Config/ReleaseOptions.php
+++ b/src/Config/ReleaseOptions.php
@@ -42,6 +42,7 @@ final readonly class ReleaseOptions
         private string $tagName = '{%version%}',
         private bool $overwriteExistingTag = false,
         private bool $signTag = false,
+        private bool $createTag = true,
     ) {
         if (!Helper\VersionHelper::isValidVersionPattern($this->tagName)) {
             throw new Exception\TagNameIsInvalid($this->tagName);
@@ -66,5 +67,10 @@ final readonly class ReleaseOptions
     public function signTag(): bool
     {
         return $this->signTag;
+    }
+
+    public function createTag(): bool
+    {
+        return $this->createTag;
     }
 }

--- a/src/Result/VersionReleaseResult.php
+++ b/src/Result/VersionReleaseResult.php
@@ -38,7 +38,7 @@ final readonly class VersionReleaseResult
      */
     public function __construct(
         private array $committedFiles,
-        private string $tagName,
+        private ?string $tagName,
         private ?string $commitMessage,
         private ?string $commitId,
     ) {}
@@ -51,7 +51,7 @@ final readonly class VersionReleaseResult
         return $this->committedFiles;
     }
 
-    public function tagName(): string
+    public function tagName(): ?string
     {
         return $this->tagName;
     }

--- a/src/Version/VersionReleaser.php
+++ b/src/Version/VersionReleaser.php
@@ -77,22 +77,26 @@ final readonly class VersionReleaser
         }
 
         $modifiedFiles = $this->extractModifiedFilesFromResults($results);
-        $tagName = Helper\VersionHelper::replaceVersionInPattern($options->tagName(), $version);
+        $tagName = null;
 
-        // Check if tag already exists
-        if (null !== $repository->getTag($tagName)) {
-            if (!$options->overwriteExistingTag()) {
-                throw new Exception\TagAlreadyExists($tagName);
-            }
+        if ($options->createTag()) {
+            $tagName = Helper\VersionHelper::replaceVersionInPattern($options->tagName(), $version);
 
-            if (!$dryRun) {
-                $repository->deleteTag($tagName);
+            // Check if tag already exists
+            if (null !== $repository->getTag($tagName)) {
+                if (!$options->overwriteExistingTag()) {
+                    throw new Exception\TagAlreadyExists($tagName);
+                }
+
+                if (!$dryRun) {
+                    $repository->deleteTag($tagName);
+                }
             }
         }
 
         [$commitMessage, $commitId] = $this->commitModifiedFiles($modifiedFiles, $repository, $options, $version, $dryRun);
 
-        if (!$dryRun) {
+        if ($options->createTag() && !$dryRun) {
             $tagCommand = Command\TagCommand::getInstance($repository)->create($tagName, null, $tagName);
 
             if ($options->signTag()) {

--- a/tests/unit/Command/BumpVersionCommandTest.php
+++ b/tests/unit/Command/BumpVersionCommandTest.php
@@ -660,6 +660,25 @@ final class BumpVersionCommandTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function executeDecoratesVersionReleaseResultWithoutTagIfTagCreationIsDisabled(): void
+    {
+        $configFile = dirname(__DIR__).'/Fixtures/ConfigFiles/valid-config-with-root-path-and-no-tag.json';
+
+        $this->commandTester->execute([
+            'range' => '0.1.0',
+            '--config' => $configFile,
+            '--dry-run' => true,
+            '--release' => true,
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertSame(Console\Command\Command::SUCCESS, $this->commandTester->getStatusCode());
+        self::assertStringContainsString('Committed: Release 0.1.0', $output);
+        self::assertStringNotContainsString('Tagged:', $output);
+    }
+
+    #[Framework\Attributes\Test]
     public function executeFailsIfUnmatchedPatternIsReportedInStrictMode(): void
     {
         $configFile = dirname(__DIR__).'/Fixtures/ConfigFiles/valid-config-with-root-path.json';

--- a/tests/unit/Config/ReleaseOptionsTest.php
+++ b/tests/unit/Config/ReleaseOptionsTest.php
@@ -44,4 +44,16 @@ final class ReleaseOptionsTest extends Framework\TestCase
 
         new Src\Config\ReleaseOptions(tagName: 'foo');
     }
+
+    #[Framework\Attributes\Test]
+    public function createTagDefaultsToTrue(): void
+    {
+        self::assertTrue((new Src\Config\ReleaseOptions())->createTag());
+    }
+
+    #[Framework\Attributes\Test]
+    public function createTagReturnsConfiguredValue(): void
+    {
+        self::assertFalse((new Src\Config\ReleaseOptions(createTag: false))->createTag());
+    }
 }

--- a/tests/unit/Config/ReleaseOptionsTest.php
+++ b/tests/unit/Config/ReleaseOptionsTest.php
@@ -44,16 +44,4 @@ final class ReleaseOptionsTest extends Framework\TestCase
 
         new Src\Config\ReleaseOptions(tagName: 'foo');
     }
-
-    #[Framework\Attributes\Test]
-    public function createTagDefaultsToTrue(): void
-    {
-        self::assertTrue((new Src\Config\ReleaseOptions())->createTag());
-    }
-
-    #[Framework\Attributes\Test]
-    public function createTagReturnsConfiguredValue(): void
-    {
-        self::assertFalse((new Src\Config\ReleaseOptions(createTag: false))->createTag());
-    }
 }

--- a/tests/unit/Fixtures/ConfigFiles/valid-config-with-root-path-and-no-tag.json
+++ b/tests/unit/Fixtures/ConfigFiles/valid-config-with-root-path-and-no-tag.json
@@ -1,0 +1,29 @@
+{
+	"filesToModify": [
+		{
+			"path": "foo",
+			"patterns": [
+				"baz: {%version%}",
+				"foo: {%version%}"
+			],
+			"reportUnmatched": true
+		},
+		{
+			"path": "baz",
+			"patterns": [
+				"baz: {%version%}",
+				"foo: {%version%}"
+			]
+		},
+		{
+			"path": "foobaz",
+			"patterns": [
+				"foo: {%version%}"
+			]
+		}
+	],
+	"releaseOptions": {
+		"createTag": false
+	},
+	"rootPath": "../RootPath"
+}

--- a/tests/unit/Version/VersionReleaserTest.php
+++ b/tests/unit/Version/VersionReleaserTest.php
@@ -420,6 +420,34 @@ TAGS;
     }
 
     #[Framework\Attributes\Test]
+    public function releaseSkipsTagCreationAndExistenceCheckIfCreateTagIsDisabled(): void
+    {
+        $this->caller
+            ->addResult("add '--all' 'composer.json'", '')
+            ->addResult("commit '-m' 'Release 2.0.0'", '')
+            ->addResult("show '-s' '--pretty=raw' '--no-color' 'HEAD'", 'commit cf79760440d4a34c85cf9ceeefbf2140fad04eb1')
+        ;
+
+        $expected = new Src\Result\VersionReleaseResult(
+            [
+                $this->results[0]->file(),
+            ],
+            null,
+            'Release 2.0.0',
+            'cf79760440d4a34c85cf9ceeefbf2140fad04eb1',
+        );
+
+        self::assertEquals(
+            $expected,
+            $this->subject->release(
+                $this->results,
+                dirname(__DIR__, 3),
+                new Src\Config\ReleaseOptions(createTag: false),
+            ),
+        );
+    }
+
+    #[Framework\Attributes\Test]
     public function releaseDoesNotPerformAnyWriteOperationsInDryRunMode(): void
     {
         $this->caller->addResult('tag', '');


### PR DESCRIPTION
## Summary

- Adds `releaseOptions.createTag` (boolean, default `true`) so `--release` can commit changed files without creating a Git tag
- When `createTag` is `false`, the tag-existence check, `overwriteExistingTag` handling, and tag creation are all skipped entirely; the release commit still runs
- `Result\VersionReleaseResult::tagName()` is now `?string` to reflect that no tag was created; the `Tagged: ...` line is omitted from the CLI output in that case

Closes #165

## Test plan
- [x] `composer test` — 268 tests, 493 assertions, green
- [x] `composer check:static` (PHPStan)
- [x] `composer check:style` (composer-normalize, EditorConfig, PHP CS Fixer)
- [x] `composer check:deps` and `composer check:refactor` (Rector dry-run)
- [x] New unit tests cover `createTag: false` at the `ReleaseOptions`, `VersionReleaser`, and `BumpVersionCommand` level